### PR TITLE
feat(network): 总状态栏支持监控节点链接外网情况

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ data/
 packages/ui/android/app/build/
 packages/ui/android/.gradle/
 packages/ui/android/app/src/main/assets/public/
+
+CLAUDE.md

--- a/agent/pmeow/__main__.py
+++ b/agent/pmeow/__main__.py
@@ -65,7 +65,7 @@ def _cmd_submit(args: argparse.Namespace) -> None:
     resp = send_request(_socket_path(args), "submit_task", {
         "command": command,
         "cwd": os.getcwd(),
-        "user": os.environ.get("USER", "unknown"),
+        "user": os.environ.get("USER") or os.environ.get("USERNAME", "unknown"),
         "require_vram_mb": args.pvram,
         "require_gpu_count": args.gpu,
         "priority": args.priority,

--- a/agent/pmeow/collector/gpu_attribution.py
+++ b/agent/pmeow/collector/gpu_attribution.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import os
-import pwd
+import sys
 from collections import defaultdict
 from typing import Optional
+
+import psutil
+
+try:
+    import pwd  # Unix only
+except ImportError:
+    pwd = None  # type: ignore[assignment]
 
 from pmeow.models import (
     GpuAllocationSummary,
@@ -20,34 +27,59 @@ from pmeow.models import (
 
 
 def _read_proc_uid(pid: int) -> Optional[int]:
-    """Read the real UID from /proc/<pid>/status, or None."""
-    try:
-        with open(f"/proc/{pid}/status") as f:
-            for line in f:
-                if line.startswith("Uid:"):
-                    return int(line.split()[1])
-    except (OSError, ValueError, IndexError):
+    """Read the real UID from /proc/<pid>/status, or None.
+
+    Falls back to psutil on platforms without /proc (e.g. Windows).
+    """
+    if sys.platform != "win32":
+        try:
+            with open(f"/proc/{pid}/status") as f:
+                for line in f:
+                    if line.startswith("Uid:"):
+                        return int(line.split()[1])
+        except (OSError, ValueError, IndexError):
+            return None
         return None
+    # Windows: UID is not meaningful; return None so callers bucket
+    # the process by username instead.
     return None
 
 
 def _read_proc_cmdline(pid: int) -> Optional[str]:
-    """Read the command line from /proc/<pid>/cmdline, or None."""
-    try:
-        with open(f"/proc/{pid}/cmdline", "rb") as f:
-            raw = f.read(4096)
-        if not raw:
+    """Read the command line from /proc/<pid>/cmdline, or None.
+
+    Falls back to psutil on platforms without /proc (e.g. Windows).
+    """
+    if sys.platform != "win32":
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as f:
+                raw = f.read(4096)
+            if not raw:
+                return None
+            return raw.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
+        except OSError:
             return None
-        return raw.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
-    except OSError:
+    try:
+        return " ".join(psutil.Process(pid).cmdline())
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return None
+
+
+def _get_process_username(pid: int) -> Optional[str]:
+    """Return the username owning *pid*, or None."""
+    try:
+        return psutil.Process(pid).username()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
         return None
 
 
 def _uid_to_username(uid: int) -> str:
-    try:
-        return pwd.getpwuid(uid).pw_name
-    except KeyError:
-        return str(uid)
+    if pwd is not None:
+        try:
+            return pwd.getpwuid(uid).pw_name
+        except KeyError:
+            pass
+    return str(uid)
 
 
 def calculate_effective_free(
@@ -111,10 +143,14 @@ def attribute_gpu_processes(
             ))
             continue
 
-        # Try to identify user via /proc
+        # Try to identify user via /proc or psutil
         uid = _read_proc_uid(proc.pid)
         if uid is not None:
-            username = _uid_to_username(uid)
+            username: Optional[str] = _uid_to_username(uid)
+        else:
+            username = _get_process_username(proc.pid)
+
+        if username is not None:
             cmdline = _read_proc_cmdline(proc.pid) or ""
             user_procs[gpu_idx].append(GpuUserProcess(
                 pid=proc.pid,
@@ -130,7 +166,7 @@ def attribute_gpu_processes(
             user_usage[username]["gpus"].add(gpu_idx)  # type: ignore[union-attr]
             continue
 
-        # Unreadable /proc → unknown
+        # Unidentifiable process → unknown
         unknown_procs[gpu_idx].append(GpuUnknownProcess(
             pid=proc.pid,
             gpu_index=gpu_idx,

--- a/agent/pmeow/collector/internet.py
+++ b/agent/pmeow/collector/internet.py
@@ -1,0 +1,196 @@
+"""Internet reachability probe.
+
+This collector is intentionally separate from `collector/network.py` because:
+
+- Network byte-counter collection must run every cycle to produce rates.
+- Probing an external host on every collection cycle is wasteful and would
+  add 5s-interval x 3s-timeout worth of outbound TCP attempts when the link is
+  down. The probe is therefore cached and only refreshed on its own interval.
+
+The probe uses TCP ``connect(target_host, target_port)`` rather than ICMP ping
+because ICMP is commonly blocked on hardened hosts and requires extra
+privileges, while TCP 443 is almost always allowed outbound.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+_DEFAULT_TARGETS = "1.1.1.1:443,8.8.8.8:443"
+_DEFAULT_TIMEOUT_SECONDS = 3.0
+_DEFAULT_INTERVAL_SECONDS = 30.0
+
+
+@dataclass
+class InternetProbeResult:
+    """Outcome of a single internet reachability probe run."""
+
+    reachable: bool
+    latency_ms: Optional[float]
+    probe_target: str
+    checked_at: float
+
+
+def _parse_targets(raw: str) -> list[tuple[str, int]]:
+    """Parse ``"host:port,host:port"`` into validated ``(host, port)`` tuples.
+
+    Silently drops malformed entries so a typo in the env var does not crash
+    the agent. Returns an empty list when ``raw`` is empty or all entries are
+    invalid; callers must treat that as "probe disabled".
+    """
+    targets: list[tuple[str, int]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        host, _, port_str = entry.rpartition(":")
+        if not host or not port_str:
+            continue
+        try:
+            port = int(port_str)
+        except ValueError:
+            continue
+        if not (0 < port < 65536):
+            continue
+        targets.append((host, port))
+    return targets
+
+
+def _probe_once(host: str, port: int, timeout_seconds: float) -> Optional[float]:
+    """Attempt a TCP connect to ``host:port``.
+
+    Returns the latency in milliseconds on success, or ``None`` if the connect
+    failed or timed out. Uses ``monotonic`` so the latency is not affected by
+    wall-clock adjustments between start and finish.
+    """
+    t0 = time.monotonic()
+    try:
+        with socket.create_connection((host, port), timeout=timeout_seconds):
+            return round((time.monotonic() - t0) * 1000.0, 1)
+    except OSError:
+        return None
+
+
+def probe_internet(
+    targets: list[tuple[str, int]],
+    timeout_seconds: float,
+) -> InternetProbeResult:
+    """Try each target in order until one succeeds.
+
+    The first successful target wins and its latency is reported. If every
+    target fails, the result is marked unreachable and ``latency_ms`` is
+    ``None``. The ``probe_target`` field is always set to the *first* target
+    attempted so UI consumers can display "probe target=1.1.1.1:443" even when
+    the probe failed.
+    """
+    now = time.time()
+    if not targets:
+        # Empty target list means "probe disabled" — signal unreachable with
+        # a dummy probe_target so the UI does not show a blank string.
+        return InternetProbeResult(
+            reachable=False,
+            latency_ms=None,
+            probe_target="disabled",
+            checked_at=now,
+        )
+
+    first_target = f"{targets[0][0]}:{targets[0][1]}"
+    for host, port in targets:
+        latency = _probe_once(host, port, timeout_seconds)
+        if latency is not None:
+            return InternetProbeResult(
+                reachable=True,
+                latency_ms=latency,
+                probe_target=f"{host}:{port}",
+                checked_at=now,
+            )
+    return InternetProbeResult(
+        reachable=False,
+        latency_ms=None,
+        probe_target=first_target,
+        checked_at=now,
+    )
+
+
+class InternetProbe:
+    """Cached internet reachability probe.
+
+    Wrap ``probe_internet`` with an interval-based cache so repeated metrics
+    cycles do not hammer the probe targets. The cache is monotonic-time based
+    so wall-clock jumps never skip a refresh.
+    """
+
+    def __init__(
+        self,
+        targets: Optional[list[tuple[str, int]]] = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        interval_seconds: float = _DEFAULT_INTERVAL_SECONDS,
+    ) -> None:
+        self._targets = targets if targets is not None else _parse_targets(_DEFAULT_TARGETS)
+        self._timeout_seconds = timeout_seconds
+        self._interval_seconds = interval_seconds
+        self._last_result: Optional[InternetProbeResult] = None
+        self._last_run_monotonic: Optional[float] = None
+
+    @property
+    def enabled(self) -> bool:
+        """True when this probe has at least one valid target configured."""
+        return bool(self._targets)
+
+    def get(self, now_monotonic: Optional[float] = None) -> Optional[InternetProbeResult]:
+        """Return the current cached probe result, refreshing if stale.
+
+        Returns ``None`` when the probe is disabled (no targets configured);
+        callers should treat this as "no data to report".
+        """
+        if not self._targets:
+            return None
+        now = now_monotonic if now_monotonic is not None else time.monotonic()
+        if (
+            self._last_result is None
+            or self._last_run_monotonic is None
+            or (now - self._last_run_monotonic) >= self._interval_seconds
+        ):
+            self._last_result = probe_internet(self._targets, self._timeout_seconds)
+            self._last_run_monotonic = now
+        return self._last_result
+
+
+def load_probe_from_env(env: Optional[dict[str, str]] = None) -> InternetProbe:
+    """Build an ``InternetProbe`` from ``PMEOW_INTERNET_PROBE_*`` env vars.
+
+    Supported variables:
+
+    - ``PMEOW_INTERNET_PROBE_TARGETS``: comma-separated ``host:port`` list.
+      Default ``"1.1.1.1:443,8.8.8.8:443"``. Set to an empty string to
+      disable the probe entirely.
+    - ``PMEOW_INTERNET_PROBE_TIMEOUT``: per-target TCP connect timeout in
+      seconds. Default ``3.0``.
+    - ``PMEOW_INTERNET_PROBE_INTERVAL``: minimum seconds between probe runs.
+      Default ``30.0``. Shorter intervals waste bandwidth; longer intervals
+      delay detection of WAN outages.
+    """
+    env_map = env if env is not None else os.environ
+    raw_targets = env_map.get("PMEOW_INTERNET_PROBE_TARGETS", _DEFAULT_TARGETS)
+    targets = _parse_targets(raw_targets)
+    try:
+        timeout_seconds = float(env_map.get("PMEOW_INTERNET_PROBE_TIMEOUT", _DEFAULT_TIMEOUT_SECONDS))
+    except ValueError:
+        timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+    try:
+        interval_seconds = float(env_map.get("PMEOW_INTERNET_PROBE_INTERVAL", _DEFAULT_INTERVAL_SECONDS))
+    except ValueError:
+        interval_seconds = _DEFAULT_INTERVAL_SECONDS
+    if timeout_seconds <= 0:
+        timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+    if interval_seconds <= 0:
+        interval_seconds = _DEFAULT_INTERVAL_SECONDS
+    return InternetProbe(
+        targets=targets,
+        timeout_seconds=timeout_seconds,
+        interval_seconds=interval_seconds,
+    )

--- a/agent/pmeow/collector/local_users.py
+++ b/agent/pmeow/collector/local_users.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-import pwd
-
 from pmeow.models import LocalUserRecord
+
+try:
+    import pwd  # Unix only
+except ImportError:
+    pwd = None  # type: ignore[assignment]
 
 
 _DEFAULT_UID_MIN = 1000
@@ -34,7 +37,7 @@ def _read_uid_min() -> int:
     return _DEFAULT_UID_MIN
 
 
-def _is_bindable_user(entry: pwd.struct_passwd, uid_min: int) -> bool:
+def _is_bindable_user(entry: pwd.struct_passwd, uid_min: int) -> bool:  # type: ignore[name-defined]
     username = entry.pw_name.strip()
     if not username or username in _EXCLUDED_USERNAMES:
         return False
@@ -46,7 +49,13 @@ def _is_bindable_user(entry: pwd.struct_passwd, uid_min: int) -> bool:
 
 
 def collect_local_users(uid_min: int | None = None) -> list[LocalUserRecord]:
-    """Collect bindable local user accounts using passwd/NSS semantics."""
+    """Collect bindable local user accounts using passwd/NSS semantics.
+
+    Returns an empty list on platforms without the ``pwd`` module (e.g. Windows).
+    """
+    if pwd is None:
+        return []
+
     minimum_uid = _read_uid_min() if uid_min is None else max(1, uid_min)
     users: list[LocalUserRecord] = []
 

--- a/agent/pmeow/collector/snapshot.py
+++ b/agent/pmeow/collector/snapshot.py
@@ -18,6 +18,7 @@ from pmeow.collector.gpu import (
     collect_per_gpu_used_memory,
 )
 from pmeow.collector.gpu_attribution import attribute_gpu_processes
+from pmeow.collector.internet import InternetProbe
 from pmeow.collector.memory import collect_memory
 from pmeow.collector.network import collect_network
 from pmeow.collector.processes import collect_processes
@@ -29,8 +30,15 @@ def collect_snapshot(
     server_id: str,
     task_store: Optional[sqlite3.Connection] = None,
     redundancy_coefficient: float = 0.1,
+    internet_probe: Optional[InternetProbe] = None,
 ) -> MetricsSnapshot:
-    """Collect a full metrics snapshot for the given server."""
+    """Collect a full metrics snapshot for the given server.
+
+    ``internet_probe`` is optional and intentionally injected by the caller
+    (the daemon) rather than constructed here, so tests can supply a fake
+    probe without monkey-patching module state and so the daemon owns the
+    probe's cached state across collection cycles.
+    """
     gpu = collect_gpu()
 
     gpu_allocation = None
@@ -44,13 +52,22 @@ def collect_snapshot(
             per_gpu_used_memory=per_gpu_used,
         )
 
+    network = collect_network()
+    if internet_probe is not None:
+        probe_result = internet_probe.get()
+        if probe_result is not None:
+            network.internet_reachable = probe_result.reachable
+            network.internet_latency_ms = probe_result.latency_ms
+            network.internet_probe_target = probe_result.probe_target
+            network.internet_probe_checked_at = probe_result.checked_at
+
     return MetricsSnapshot(
         server_id=server_id,
         timestamp=time.time(),
         cpu=collect_cpu(),
         memory=collect_memory(),
         disk=collect_disk(),
-        network=collect_network(),
+        network=network,
         gpu=gpu,
         processes=collect_processes(),
         docker=collect_docker(),

--- a/agent/pmeow/collector/system.py
+++ b/agent/pmeow/collector/system.py
@@ -30,7 +30,11 @@ def collect_system() -> SystemSnapshot:
     """Collect a system snapshot."""
     boot = psutil.boot_time()
     uptime_sec = time.time() - boot
-    load1, load5, load15 = os.getloadavg()
+    try:
+        load1, load5, load15 = os.getloadavg()
+    except (OSError, AttributeError):
+        # os.getloadavg() is not available on Windows
+        load1 = load5 = load15 = 0.0
 
     return SystemSnapshot(
         hostname=socket.gethostname(),

--- a/agent/pmeow/daemon/service.py
+++ b/agent/pmeow/daemon/service.py
@@ -10,6 +10,7 @@ import time
 from typing import Iterable
 
 from pmeow import __version__
+from pmeow.collector.internet import InternetProbe, load_probe_from_env
 from pmeow.collector.local_users import collect_local_users
 from pmeow.collector.snapshot import collect_snapshot
 from pmeow.config import AgentConfig
@@ -51,7 +52,11 @@ log = logging.getLogger(__name__)
 class DaemonService:
     """Central service that coordinates collection, scheduling, and task execution."""
 
-    def __init__(self, config: AgentConfig) -> None:
+    def __init__(
+        self,
+        config: AgentConfig,
+        internet_probe: InternetProbe | None = None,
+    ) -> None:
         self.config = config
         self._lock = threading.Lock()
         self._shutdown = threading.Event()
@@ -60,6 +65,10 @@ class DaemonService:
         self.runner = TaskRunner()
         self.history = GpuHistoryTracker(window_seconds=config.history_window_seconds)
         self.scheduler = QueueScheduler(self.history)
+        # The probe carries its own cache state across collection cycles, so
+        # it must live on the service (not be recreated per cycle). Tests can
+        # inject a fake probe to avoid touching the network.
+        self.internet_probe = internet_probe if internet_probe is not None else load_probe_from_env()
 
         self.transport: AgentTransportClient | None = None
         if config.server_url:
@@ -169,6 +178,7 @@ class DaemonService:
             server_id=self.config.agent_id or "local",
             task_store=self.db,
             redundancy_coefficient=self.config.vram_redundancy_coefficient,
+            internet_probe=self.internet_probe,
         )
 
         per_gpu = (

--- a/agent/pmeow/daemon/socket_server.py
+++ b/agent/pmeow/daemon/socket_server.py
@@ -1,4 +1,9 @@
-"""Unix socket JSON-line protocol server for local daemon control."""
+"""Local JSON-line protocol server for daemon control.
+
+Uses AF_UNIX where available (Linux, macOS, Windows 10 17063+) and
+falls back to a TCP loopback socket otherwise, writing the chosen port
+into the *socket_path* file so clients can discover it.
+"""
 
 from __future__ import annotations
 
@@ -18,6 +23,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _BUF_SIZE = 65536
+_HAS_AF_UNIX = hasattr(socket, "AF_UNIX")
 
 
 class SocketServer:
@@ -41,8 +47,18 @@ class SocketServer:
         self._cleanup_stale()
         Path(self.socket_path).parent.mkdir(parents=True, exist_ok=True)
 
-        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self._sock.bind(self.socket_path)
+        if _HAS_AF_UNIX:
+            self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            self._sock.bind(self.socket_path)
+        else:
+            # Fallback: TCP on loopback; write the port to socket_path file
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self._sock.bind(("127.0.0.1", 0))
+            port = self._sock.getsockname()[1]
+            Path(self.socket_path).write_text(str(port))
+            log.info("AF_UNIX unavailable, using TCP 127.0.0.1:%d", port)
+
         self._sock.listen(5)
         self._sock.settimeout(1.0)
         log.info("socket server listening on %s", self.socket_path)
@@ -242,10 +258,21 @@ _METHODS: dict[str, Any] = {
 # ------------------------------------------------------------------
 
 def send_request(socket_path: str, method: str, params: dict | None = None) -> dict:
-    """Connect to the daemon socket, send a JSON request, return the response."""
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    """Connect to the daemon socket, send a JSON request, return the response.
+
+    Detects whether the daemon is listening on AF_UNIX or TCP loopback by
+    checking if *socket_path* contains a port number (TCP fallback mode).
+    """
+    if _HAS_AF_UNIX:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        target: str | tuple[str, int] = socket_path
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        port = int(Path(socket_path).read_text().strip())
+        target = ("127.0.0.1", port)
+
     try:
-        sock.connect(socket_path)
+        sock.connect(target)  # type: ignore[arg-type]
         payload = json.dumps({"method": method, "params": params or {}})
         sock.sendall(payload.encode())
         sock.shutdown(socket.SHUT_WR)

--- a/agent/pmeow/daemon/supervisor.py
+++ b/agent/pmeow/daemon/supervisor.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import errno
 import os
 import signal
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -29,7 +31,7 @@ def is_process_running(pid: int) -> bool:
     try:
         os.kill(pid, 0)
     except OSError as exc:
-        return exc.errno == errno.EPERM
+        return exc.errno in (errno.EPERM, errno.EACCES)
     return True
 
 
@@ -61,7 +63,18 @@ def stop_background_process(pid_file: str, timeout: float = 5.0) -> bool:
     if pid is None:
         return False
 
-    os.kill(pid, signal.SIGTERM)
+    if sys.platform == "win32":
+        # On Windows, os.kill(pid, signal.SIGTERM) calls TerminateProcess
+        # which is a hard kill.  We still attempt a graceful wait first by
+        # simply waiting for the process to finish on its own (it may have
+        # received a Ctrl+C via other means); then terminate if it hasn't.
+        if not wait_for_exit(pid, min(timeout, 1.0)):
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except OSError:
+                pass
+    else:
+        os.kill(pid, signal.SIGTERM)
     exited = wait_for_exit(pid, timeout)
     if exited:
         Path(pid_file).unlink(missing_ok=True)
@@ -71,6 +84,9 @@ def stop_background_process(pid_file: str, timeout: float = 5.0) -> bool:
 def start_background_daemon(config: AgentConfig, agent_log_file: str) -> int:
     prepare_pid_file(config.pid_file)
     Path(agent_log_file).parent.mkdir(parents=True, exist_ok=True)
+
+    if sys.platform == "win32":
+        return _start_background_win32(config, agent_log_file)
 
     pid = os.fork()
     if pid > 0:
@@ -94,3 +110,20 @@ def start_background_daemon(config: AgentConfig, agent_log_file: str) -> int:
         Path(config.pid_file).unlink(missing_ok=True)
 
     os._exit(0)
+
+
+def _start_background_win32(config: AgentConfig, agent_log_file: str) -> int:
+    """Spawn a detached background agent process on Windows."""
+    CREATE_NO_WINDOW = 0x08000000
+    log_fh = open(agent_log_file, "a")
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "pmeow", "run"],
+        stdin=subprocess.DEVNULL,
+        stdout=log_fh,
+        stderr=subprocess.STDOUT,
+        creationflags=subprocess.DETACHED_PROCESS | CREATE_NO_WINDOW,
+        env=os.environ.copy(),
+    )
+    log_fh.close()
+    write_pid_file(config.pid_file, proc.pid)
+    return proc.pid

--- a/agent/pmeow/models.py
+++ b/agent/pmeow/models.py
@@ -280,6 +280,12 @@ class NetworkSnapshot:
     rx_bytes_per_sec: float
     tx_bytes_per_sec: float
     interfaces: list[NetworkInterface] = field(default_factory=list)
+    # Internet reachability probe result (optional; None when probe is disabled
+    # or has not yet produced a sample). Mirrors NetworkMetrics on the TS side.
+    internet_reachable: Optional[bool] = None
+    internet_latency_ms: Optional[float] = None
+    internet_probe_target: Optional[str] = None
+    internet_probe_checked_at: Optional[float] = None
 
     def to_dict(self) -> dict:
         return _serialize(self)
@@ -359,4 +365,13 @@ class MetricsSnapshot:
         # gpu_allocation is agent-only; strip if None
         if self.gpu_allocation is None:
             d.pop("gpuAllocation", None)
+        # Strip internet probe fields from the network sub-dict when the agent
+        # has no probe result, so the TS payload matches the optional/undefined
+        # shape instead of carrying explicit nulls on every snapshot.
+        # _serialize is recursive and does not call nested to_dict(), so the
+        # stripping must happen at this level.
+        net = d.get("network")
+        if isinstance(net, dict) and self.network.internet_reachable is None and self.network.internet_probe_checked_at is None:
+            for key in ("internetReachable", "internetLatencyMs", "internetProbeTarget", "internetProbeCheckedAt"):
+                net.pop(key, None)
         return d

--- a/agent/tests/collector/test_base_collectors.py
+++ b/agent/tests/collector/test_base_collectors.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from pmeow.collector.cpu import collect_cpu
 from pmeow.collector.disk import collect_disk
@@ -107,7 +107,11 @@ def test_local_user_collector_filters_system_accounts_by_default():
     ]
 
     with patch("pmeow.collector.local_users._read_uid_min", return_value=1000):
-        with patch("pmeow.collector.local_users.pwd.getpwall", return_value=entries):
+        target = "pmeow.collector.local_users.pwd"
+        mock_pwd = MagicMock()
+        mock_pwd.getpwall.return_value = entries
+        mock_pwd.struct_passwd = type(entries[0])
+        with patch(target, mock_pwd):
             users = collect_local_users()
 
     assert [user.username for user in users] == ["alice"]

--- a/agent/tests/collector/test_gpu.py
+++ b/agent/tests/collector/test_gpu.py
@@ -197,32 +197,15 @@ class TestAttributionPmeowTask:
 class TestAttributionUserProcess:
     def test_proc_readable(self):
         proc = GpuProcessInfo(pid=9999, gpu_index=0, used_memory_mb=3000.0, process_name="")
-        status_content = "Name:\tpython\nUid:\t1000\t1000\t1000\t1000\n"
-        cmdline_content = b"python\x00train.py\x00--lr=0.01"
 
-        import builtins
-
-        real_open = builtins.open
-
-        def _fake_open(path, *args, **kwargs):
-            if path == "/proc/9999/status":
-                return mock_open(read_data=status_content)()
-            if path == "/proc/9999/cmdline":
-                m = MagicMock()
-                m.__enter__ = lambda s: s
-                m.__exit__ = MagicMock(return_value=False)
-                m.read = MagicMock(return_value=cmdline_content)
-                return m
-            return real_open(path, *args, **kwargs)
-
-        with patch("pmeow.collector.gpu_attribution.pwd.getpwuid") as mock_pw:
-            mock_pw.return_value = MagicMock(pw_name="testuser")
-            with patch("builtins.open", side_effect=_fake_open):
-                summary = attribute_gpu_processes(
-                    gpu_processes=[proc],
-                    running_tasks=[],
-                    per_gpu_memory={0: 24000.0},
-                )
+        with patch("pmeow.collector.gpu_attribution._read_proc_uid", return_value=1000):
+            with patch("pmeow.collector.gpu_attribution._uid_to_username", return_value="testuser"):
+                with patch("pmeow.collector.gpu_attribution._read_proc_cmdline", return_value="python train.py --lr=0.01"):
+                    summary = attribute_gpu_processes(
+                        gpu_processes=[proc],
+                        running_tasks=[],
+                        per_gpu_memory={0: 24000.0},
+                    )
         assert len(summary.per_gpu[0].user_processes) == 1
         up = summary.per_gpu[0].user_processes[0]
         assert isinstance(up, GpuUserProcess)

--- a/agent/tests/collector/test_internet.py
+++ b/agent/tests/collector/test_internet.py
@@ -1,0 +1,208 @@
+"""Tests for the internet reachability probe collector."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pmeow.collector.internet as internet_mod
+from pmeow.collector.internet import (
+    InternetProbe,
+    InternetProbeResult,
+    _parse_targets,
+    load_probe_from_env,
+    probe_internet,
+)
+
+
+# ---------- _parse_targets ----------
+
+def test_parse_targets_basic() -> None:
+    targets = _parse_targets("1.1.1.1:443,8.8.8.8:53")
+    assert targets == [("1.1.1.1", 443), ("8.8.8.8", 53)]
+
+
+def test_parse_targets_empty_string() -> None:
+    assert _parse_targets("") == []
+
+
+def test_parse_targets_ignores_malformed_entries() -> None:
+    targets = _parse_targets("1.1.1.1:443,badentry,:80,999.999.999.999:99999")
+    # Only the first entry is valid (port 99999 > 65535 is rejected)
+    assert targets == [("1.1.1.1", 443)]
+
+
+def test_parse_targets_strips_whitespace() -> None:
+    targets = _parse_targets(" 1.1.1.1:443 , 8.8.8.8:53 ")
+    assert targets == [("1.1.1.1", 443), ("8.8.8.8", 53)]
+
+
+# ---------- probe_internet ----------
+
+def test_probe_internet_returns_reachable_on_success() -> None:
+    with patch(
+        "pmeow.collector.internet.socket.create_connection"
+    ) as mock_conn, patch(
+        "pmeow.collector.internet.time.monotonic",
+        side_effect=[1.0, 1.025],
+    ), patch(
+        "pmeow.collector.internet.time.time",
+        return_value=1712000000.0,
+    ):
+        mock_conn.return_value.__enter__ = lambda self: self
+        mock_conn.return_value.__exit__ = lambda *args: False
+
+        result = probe_internet([("1.1.1.1", 443)], timeout_seconds=3.0)
+
+    assert result.reachable is True
+    assert result.latency_ms == 25.0
+    assert result.probe_target == "1.1.1.1:443"
+    assert result.checked_at == 1712000000.0
+
+
+def test_probe_internet_returns_unreachable_when_all_fail() -> None:
+    with patch(
+        "pmeow.collector.internet.socket.create_connection",
+        side_effect=OSError("connection refused"),
+    ), patch(
+        "pmeow.collector.internet.time.time",
+        return_value=1712000000.0,
+    ):
+        result = probe_internet(
+            [("1.1.1.1", 443), ("8.8.8.8", 443)], timeout_seconds=3.0,
+        )
+
+    assert result.reachable is False
+    assert result.latency_ms is None
+    assert result.probe_target == "1.1.1.1:443"
+
+
+def test_probe_internet_tries_second_target_on_first_failure() -> None:
+    call_count = 0
+
+    def _side_effect(addr, timeout):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError("refused")
+        cm = type("CM", (), {
+            "__enter__": lambda self: self,
+            "__exit__": lambda *a: False,
+        })()
+        return cm
+
+    with patch(
+        "pmeow.collector.internet.socket.create_connection",
+        side_effect=_side_effect,
+    ), patch(
+        # monotonic() call trace:
+        #   1st target → t0 (before connect) → raises OSError → no 2nd call
+        #   2nd target → t0 (before connect) → success → t1 (after connect)
+        # Total: 3 monotonic() calls.
+        "pmeow.collector.internet.time.monotonic",
+        side_effect=[1.0, 2.0, 2.010],
+    ), patch(
+        "pmeow.collector.internet.time.time",
+        return_value=1712000000.0,
+    ):
+        result = probe_internet(
+            [("1.1.1.1", 443), ("8.8.8.8", 443)], timeout_seconds=3.0,
+        )
+
+    assert result.reachable is True
+    assert result.latency_ms == 10.0
+    assert result.probe_target == "8.8.8.8:443"
+
+
+def test_probe_internet_empty_targets() -> None:
+    result = probe_internet([], timeout_seconds=3.0)
+    assert result.reachable is False
+    assert result.probe_target == "disabled"
+
+
+# ---------- InternetProbe (caching) ----------
+
+def test_internet_probe_caches_result_within_interval() -> None:
+    probe = InternetProbe(
+        targets=[("1.1.1.1", 443)],
+        timeout_seconds=3.0,
+        interval_seconds=30.0,
+    )
+
+    fake_result = InternetProbeResult(
+        reachable=True,
+        latency_ms=5.0,
+        probe_target="1.1.1.1:443",
+        checked_at=1712000000.0,
+    )
+
+    with patch.object(
+        internet_mod, "probe_internet", return_value=fake_result,
+    ) as mock_probe:
+        first = probe.get(now_monotonic=100.0)
+        second = probe.get(now_monotonic=110.0)  # 10s later, still within 30s interval
+
+    assert first is second
+    assert mock_probe.call_count == 1
+
+
+def test_internet_probe_refreshes_after_interval_expires() -> None:
+    probe = InternetProbe(
+        targets=[("1.1.1.1", 443)],
+        timeout_seconds=3.0,
+        interval_seconds=30.0,
+    )
+
+    result1 = InternetProbeResult(
+        reachable=True, latency_ms=5.0,
+        probe_target="1.1.1.1:443", checked_at=1712000000.0,
+    )
+    result2 = InternetProbeResult(
+        reachable=False, latency_ms=None,
+        probe_target="1.1.1.1:443", checked_at=1712000060.0,
+    )
+
+    with patch.object(
+        internet_mod, "probe_internet", side_effect=[result1, result2],
+    ) as mock_probe:
+        first = probe.get(now_monotonic=100.0)
+        second = probe.get(now_monotonic=131.0)  # 31s later, past the 30s interval
+
+    assert first is result1
+    assert second is result2
+    assert mock_probe.call_count == 2
+
+
+def test_internet_probe_returns_none_when_disabled() -> None:
+    probe = InternetProbe(targets=[], timeout_seconds=3.0, interval_seconds=30.0)
+    assert probe.get() is None
+    assert probe.enabled is False
+
+
+# ---------- load_probe_from_env ----------
+
+def test_load_probe_from_env_defaults() -> None:
+    probe = load_probe_from_env(env={})
+    assert probe.enabled is True
+
+
+def test_load_probe_from_env_custom_targets() -> None:
+    probe = load_probe_from_env(env={
+        "PMEOW_INTERNET_PROBE_TARGETS": "10.0.0.1:80",
+    })
+    assert probe.enabled is True
+    assert probe._targets == [("10.0.0.1", 80)]
+
+
+def test_load_probe_from_env_empty_targets_disables() -> None:
+    probe = load_probe_from_env(env={
+        "PMEOW_INTERNET_PROBE_TARGETS": "",
+    })
+    assert probe.enabled is False
+    assert probe.get() is None
+
+
+def test_load_probe_from_env_bad_timeout_uses_default() -> None:
+    probe = load_probe_from_env(env={
+        "PMEOW_INTERNET_PROBE_TIMEOUT": "not_a_number",
+    })
+    assert probe._timeout_seconds == 3.0

--- a/agent/tests/daemon/test_supervisor.py
+++ b/agent/tests/daemon/test_supervisor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import signal
+import sys
 
 import pytest
 
@@ -44,7 +45,13 @@ def test_stop_background_process_signals_and_removes_pid_file(tmp_path, monkeypa
     monkeypatch.setattr("pmeow.daemon.supervisor.wait_for_exit", lambda pid, timeout: True)
 
     assert stop_background_process(str(pid_file), timeout=1.0) is True
-    assert calls == [(9876, signal.SIGTERM)]
+    if sys.platform == "win32":
+        # On Windows, stop_background_process waits briefly then calls
+        # os.kill only if the process hasn't exited yet.  The monkeypatched
+        # wait_for_exit returns True immediately, so no kill is expected.
+        assert calls == []
+    else:
+        assert calls == [(9876, signal.SIGTERM)]
     assert not pid_file.exists()
 
 

--- a/agent/tests/test_models.py
+++ b/agent/tests/test_models.py
@@ -196,6 +196,41 @@ class TestMetricsSnapshot:
         iface = net["interfaces"][0]
         assert set(iface.keys()) == {"name", "rxBytes", "txBytes"}
 
+    def test_to_dict_network_omits_internet_fields_when_not_set(self):
+        """When the probe has not run, the optional internet fields must be
+        absent from the serialized dict — not present-but-null — so the TS
+        consumer treats them as ``undefined``."""
+        d = _make_snapshot().to_dict()
+        net = d["network"]
+        assert "internetReachable" not in net
+        assert "internetLatencyMs" not in net
+        assert "internetProbeTarget" not in net
+        assert "internetProbeCheckedAt" not in net
+
+    def test_to_dict_network_includes_internet_fields_when_set(self):
+        snap = _make_snapshot()
+        snap.network.internet_reachable = True
+        snap.network.internet_latency_ms = 25.0
+        snap.network.internet_probe_target = "1.1.1.1:443"
+        snap.network.internet_probe_checked_at = 1712000000.0
+        d = snap.to_dict()
+        net = d["network"]
+        assert net["internetReachable"] is True
+        assert net["internetLatencyMs"] == 25.0
+        assert net["internetProbeTarget"] == "1.1.1.1:443"
+        assert net["internetProbeCheckedAt"] == 1712000000.0
+
+    def test_to_dict_network_internet_unreachable_keeps_null_latency(self):
+        snap = _make_snapshot()
+        snap.network.internet_reachable = False
+        snap.network.internet_latency_ms = None
+        snap.network.internet_probe_target = "1.1.1.1:443"
+        snap.network.internet_probe_checked_at = 1712000000.0
+        d = snap.to_dict()
+        net = d["network"]
+        assert net["internetReachable"] is False
+        assert net["internetLatencyMs"] is None
+
     def test_to_dict_gpu_keys(self):
         d = _make_snapshot().to_dict()
         gpu = d["gpu"]

--- a/packages/core/src/ssh/collectors/network.ts
+++ b/packages/core/src/ssh/collectors/network.ts
@@ -1,17 +1,89 @@
 import type { SSHManager } from '../manager.js';
 import type { NetworkMetrics } from '../../types.js';
 
-export async function collectNetwork(ssh: SSHManager, serverId: string): Promise<NetworkMetrics> {
-  const script = `
-    cat /proc/net/dev
-    sleep 0.5
-    cat /proc/net/dev
-  `;
+// Default probe target. Using a TCP connect against 1.1.1.1:443 (Cloudflare) so the
+// check does not depend on ICMP (which is commonly blocked on hardened hosts) and
+// does not require extra privileges on the remote side.
+const DEFAULT_SSH_INTERNET_PROBE_TARGET = '1.1.1.1:443';
+const SSH_INTERNET_PROBE_TIMEOUT_SECONDS = 3;
+
+// Marker string used to split the two phases of the remote script. Chosen so it
+// cannot collide with anything /proc/net/dev or bash timing output would print.
+const PROBE_SECTION_MARKER = '---PROBE---';
+
+export interface CollectNetworkOptions {
+  /** Override probe target (``host:port``). Set to empty string to disable the probe. */
+  probeTarget?: string;
+  /** Override per-probe connect timeout in seconds. */
+  probeTimeoutSeconds?: number;
+}
+
+export async function collectNetwork(
+  ssh: SSHManager,
+  serverId: string,
+  options: CollectNetworkOptions = {},
+): Promise<NetworkMetrics> {
+  const probeTarget = options.probeTarget ?? DEFAULT_SSH_INTERNET_PROBE_TARGET;
+  const probeTimeout = options.probeTimeoutSeconds ?? SSH_INTERNET_PROBE_TIMEOUT_SECONDS;
+  const script = buildNetworkScript(probeTarget, probeTimeout);
   const output = await ssh.exec(serverId, script);
 
-  // Split into two snapshots by counting header lines
-  const lines = output.trim().split('\n');
-  const headerCount = 2; // "Inter-|" and "face |bytes..."
+  // Split the combined output into the /proc/net/dev half and the probe half.
+  // The marker is emitted by the remote shell between the two phases, so any
+  // error before the marker is isolated from the probe parsing logic.
+  const [netdevSection, probeSection = ''] = output.split(PROBE_SECTION_MARKER);
+
+  const metrics = parseNetDevPair(netdevSection);
+
+  if (probeTarget) {
+    const probe = parseProbeSection(probeSection, probeTarget);
+    metrics.internetReachable = probe.reachable;
+    metrics.internetLatencyMs = probe.latencyMs;
+    metrics.internetProbeTarget = probeTarget;
+    metrics.internetProbeCheckedAt = Date.now();
+  }
+
+  return metrics;
+}
+
+function buildNetworkScript(probeTarget: string, timeoutSeconds: number): string {
+  // The probe uses bash's ``/dev/tcp`` pseudo-device paired with the ``time``
+  // builtin. We prefer this over invoking ``curl`` or ``nc`` because:
+  //
+  // 1. ``/dev/tcp`` is always available on bash without installing anything.
+  // 2. The ``timeout`` coreutils binary guarantees we never block past the
+  //    configured limit even on a hung connect.
+  // 3. Parsing ``time -p`` output is stable across distros (POSIX format).
+  //
+  // When the target is empty the probe is skipped entirely — the remote host
+  // simply emits "DISABLED" after the marker so the parser knows to surface
+  // ``internetReachable`` as undefined.
+  const netdevPhase = 'cat /proc/net/dev; sleep 0.5; cat /proc/net/dev';
+  if (!probeTarget) {
+    return `${netdevPhase}\necho "${PROBE_SECTION_MARKER}"\necho "DISABLED"\n`;
+  }
+  const [host, portRaw] = probeTarget.split(':');
+  const port = portRaw || '443';
+  // Quote host/port so shell metacharacters in a user-supplied target cannot
+  // break out of the redirection.
+  const safeHost = shellQuote(host);
+  const safePort = shellQuote(port);
+  const probePhase = [
+    `( { time -p timeout ${timeoutSeconds} bash -c 'exec 9<>/dev/tcp/${safeHost}/${safePort}'; } 2>&1 )`,
+    `echo "EXIT=$?"`,
+  ].join('\n');
+  return `${netdevPhase}\necho "${PROBE_SECTION_MARKER}"\n${probePhase}\n`;
+}
+
+function shellQuote(value: string): string {
+  // Minimal safe quoting — we only accept the host/port characters we want to
+  // allow and drop everything else. This is defensive because the probe
+  // target may ultimately come from settings or an env override.
+  return value.replace(/[^A-Za-z0-9._-]/g, '');
+}
+
+function parseNetDevPair(netdevOutput: string): NetworkMetrics {
+  const lines = netdevOutput.trim().split('\n');
   const dataLines = lines.filter(l => l.includes(':') && !l.includes('|'));
   const half = Math.floor(dataLines.length / 2);
 
@@ -39,6 +111,53 @@ export async function collectNetwork(ssh: SSHManager, serverId: string): Promise
     txBytesPerSec: Math.round(totalTxDiff / 0.5),
     interfaces,
   };
+}
+
+interface ProbeParseResult {
+  reachable: boolean;
+  latencyMs: number | null;
+}
+
+export function parseProbeSection(probeSection: string, probeTarget: string): ProbeParseResult {
+  const trimmed = probeSection.trim();
+  if (!trimmed || trimmed === 'DISABLED') {
+    // Probe skipped — tell caller it was disabled; caller will leave the
+    // optional fields unset.
+    return { reachable: false, latencyMs: null };
+  }
+
+  // Look for the ``EXIT=N`` line. A zero exit means both the timeout wrapper
+  // and the /dev/tcp redirection succeeded — i.e. the target accepted the
+  // TCP connection before the deadline.
+  const exitMatch = trimmed.match(/EXIT=(\d+)/);
+  if (!exitMatch) {
+    return { reachable: false, latencyMs: null };
+  }
+  const exitCode = parseInt(exitMatch[1], 10);
+  if (exitCode !== 0) {
+    // Non-zero exit: host unreachable, timeout tripped, or target refused.
+    // We still parse latency if ``time -p`` printed one, but report it as
+    // null because the connect did not actually succeed.
+    void probeTarget;
+    return { reachable: false, latencyMs: null };
+  }
+
+  // ``time -p`` emits three lines (real/user/sys) separated by spaces.
+  // Example:
+  //   real 0.12
+  //   user 0.00
+  //   sys 0.00
+  // We use the ``real`` line because it is wall-clock and therefore matches
+  // what a user would intuitively call "latency".
+  const realMatch = trimmed.match(/real\s+([0-9]+\.[0-9]+)/);
+  if (!realMatch) {
+    return { reachable: true, latencyMs: null };
+  }
+  const realSeconds = parseFloat(realMatch[1]);
+  if (!isFinite(realSeconds) || realSeconds < 0) {
+    return { reachable: true, latencyMs: null };
+  }
+  return { reachable: true, latencyMs: Math.round(realSeconds * 1000 * 10) / 10 };
 }
 
 function parseNetDev(lines: string[]): Map<string, { rxBytes: number; txBytes: number }> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,6 +67,12 @@ export interface NetworkMetrics {
     rxBytes: number;
     txBytes: number;
   }[];
+  // Internet reachability probe result (optional; populated by sources that support it).
+  // Unset on snapshots where the probe is unavailable or has not yet produced a sample.
+  internetReachable?: boolean;            // overall reachability decision
+  internetLatencyMs?: number | null;      // latency in ms to the first successful target; null when unreachable
+  internetProbeTarget?: string;           // target that was probed, e.g. "1.1.1.1:443"
+  internetProbeCheckedAt?: number;        // ms epoch when the probe result was produced
 }
 
 export interface GpuMetrics {

--- a/packages/core/tests/datasource/ssh-network-collector.test.ts
+++ b/packages/core/tests/datasource/ssh-network-collector.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { collectNetwork, parseProbeSection } from '../../src/ssh/collectors/network.js';
+
+const NET_DEV_OUTPUT = [
+  // First snapshot
+  '  eth0: 1000 0 0 0 0 0 0 0 2000 0 0 0 0 0 0 0',
+  '    lo: 500 0 0 0 0 0 0 0 500 0 0 0 0 0 0 0',
+  // Second snapshot (after sleep 0.5)
+  '  eth0: 1500 0 0 0 0 0 0 0 3000 0 0 0 0 0 0 0',
+  '    lo: 600 0 0 0 0 0 0 0 600 0 0 0 0 0 0 0',
+].join('\n');
+
+describe('collectNetwork', () => {
+  it('parses /proc/net/dev and internet probe when both succeed', async () => {
+    const probeOutput = [
+      '',
+      'real 0.05',
+      'user 0.00',
+      'sys 0.00',
+      'EXIT=0',
+    ].join('\n');
+
+    const ssh = {
+      exec: vi.fn(async () => `${NET_DEV_OUTPUT}\n---PROBE---\n${probeOutput}`),
+    } as any;
+
+    const result = await collectNetwork(ssh, 'srv-1');
+
+    expect(result.rxBytesPerSec).toBe(Math.round(500 / 0.5));
+    expect(result.txBytesPerSec).toBe(Math.round(1000 / 0.5));
+    expect(result.interfaces).toEqual([
+      { name: 'eth0', rxBytes: 1500, txBytes: 3000 },
+    ]);
+    expect(result.internetReachable).toBe(true);
+    expect(result.internetLatencyMs).toBe(50.0);
+    expect(result.internetProbeTarget).toBe('1.1.1.1:443');
+    expect(result.internetProbeCheckedAt).toBeTypeOf('number');
+  });
+
+  it('marks unreachable when probe exits non-zero', async () => {
+    const probeOutput = [
+      '',
+      'real 3.01',
+      'user 0.00',
+      'sys 0.00',
+      'EXIT=124',
+    ].join('\n');
+
+    const ssh = {
+      exec: vi.fn(async () => `${NET_DEV_OUTPUT}\n---PROBE---\n${probeOutput}`),
+    } as any;
+
+    const result = await collectNetwork(ssh, 'srv-1');
+
+    expect(result.internetReachable).toBe(false);
+    expect(result.internetLatencyMs).toBeNull();
+  });
+
+  it('does not set internet fields when probe is disabled', async () => {
+    const ssh = {
+      exec: vi.fn(async () => `${NET_DEV_OUTPUT}\n---PROBE---\nDISABLED`),
+    } as any;
+
+    const result = await collectNetwork(ssh, 'srv-1', { probeTarget: '' });
+
+    expect(result.internetReachable).toBeUndefined();
+    expect(result.internetLatencyMs).toBeUndefined();
+    expect(result.internetProbeTarget).toBeUndefined();
+  });
+
+  it('handles missing probe section gracefully', async () => {
+    // Legacy or broken SSH output that does not include the marker
+    const ssh = {
+      exec: vi.fn(async () => NET_DEV_OUTPUT),
+    } as any;
+
+    // Without probeTarget we still set the fields even if the probe section
+    // is empty (the default probeTarget is "1.1.1.1:443").
+    const result = await collectNetwork(ssh, 'srv-1');
+
+    // Should still parse network metrics correctly
+    expect(result.rxBytesPerSec).toBe(Math.round(500 / 0.5));
+    // Probe section is empty string, so it reports unreachable
+    expect(result.internetReachable).toBe(false);
+    expect(result.internetLatencyMs).toBeNull();
+  });
+});
+
+describe('parseProbeSection', () => {
+  it('parses a successful probe with latency', () => {
+    const section = `
+real 0.12
+user 0.00
+sys 0.00
+EXIT=0`;
+    const result = parseProbeSection(section, '1.1.1.1:443');
+    expect(result.reachable).toBe(true);
+    expect(result.latencyMs).toBe(120.0);
+  });
+
+  it('returns unreachable on timeout (exit 124)', () => {
+    const section = `
+real 3.01
+user 0.00
+sys 0.00
+EXIT=124`;
+    const result = parseProbeSection(section, '1.1.1.1:443');
+    expect(result.reachable).toBe(false);
+    expect(result.latencyMs).toBeNull();
+  });
+
+  it('returns unreachable on empty section', () => {
+    const result = parseProbeSection('', '1.1.1.1:443');
+    expect(result.reachable).toBe(false);
+    expect(result.latencyMs).toBeNull();
+  });
+
+  it('handles DISABLED marker', () => {
+    const result = parseProbeSection('DISABLED', '1.1.1.1:443');
+    expect(result.reachable).toBe(false);
+    expect(result.latencyMs).toBeNull();
+  });
+
+  it('handles missing real line but successful exit', () => {
+    const section = 'EXIT=0';
+    const result = parseProbeSection(section, '1.1.1.1:443');
+    expect(result.reachable).toBe(true);
+    expect(result.latencyMs).toBeNull();
+  });
+
+  it('parses sub-millisecond latency accurately', () => {
+    const section = `
+real 0.00
+user 0.00
+sys 0.00
+EXIT=0`;
+    const result = parseProbeSection(section, '1.1.1.1:443');
+    expect(result.reachable).toBe(true);
+    expect(result.latencyMs).toBe(0.0);
+  });
+});

--- a/packages/ui/src/pages/Overview.tsx
+++ b/packages/ui/src/pages/Overview.tsx
@@ -50,6 +50,20 @@ export function Overview() {
     (latest, snapshot) => Math.max(latest, snapshot.timestamp),
     0,
   );
+
+  // Internet reachability aggregation — only consider snapshots that carry
+  // probe results (the field is optional; SSH nodes with an older collector
+  // or Agents that have disabled the probe will not set it).
+  const networkSnapshots = Array.from(latestMetrics.values()).filter(
+    (s) => s.network.internetReachable !== undefined,
+  );
+  const internetReachableCount = networkSnapshots.filter(
+    (s) => s.network.internetReachable === true,
+  ).length;
+  const internetUnreachableCount = networkSnapshots.filter(
+    (s) => s.network.internetReachable === false,
+  ).length;
+  const hasInternetData = networkSnapshots.length > 0;
   const activeTaskGroups = [...taskQueueGroups]
     .sort((left, right) => (right.running.length + right.queued.length) - (left.running.length + left.queued.length))
     .slice(0, 3);
@@ -94,6 +108,35 @@ export function Overview() {
       badges: [],
     },
     {
+      key: 'internet',
+      label: '外网连通',
+      value: hasInternetData
+        ? `${internetReachableCount}/${networkSnapshots.length}`
+        : '--',
+      hint: !hasInternetData
+        ? '等待节点上报外网探测数据'
+        : internetUnreachableCount === 0
+          ? '所有上报节点外网畅通'
+          : `${internetUnreachableCount} 个节点外网不可达`,
+      cardClassName: !hasInternetData
+        ? 'border-white/10 bg-slate-950/30'
+        : internetUnreachableCount > 0
+          ? 'border-rose-400/20 bg-rose-500/[0.07]'
+          : 'border-emerald-400/20 bg-emerald-500/[0.06]',
+      valueClassName: 'text-slate-100',
+      hintClassName: !hasInternetData
+        ? 'text-slate-400'
+        : internetUnreachableCount > 0
+          ? 'text-rose-300/80'
+          : 'text-emerald-300/75',
+      badges: hasInternetData
+        ? [
+            { label: '可达', value: String(internetReachableCount), className: 'node-badge-base node-badge-status-online' },
+            { label: '不可达', value: String(internetUnreachableCount), className: 'node-badge-base node-badge-status-offline' },
+          ]
+        : [],
+    },
+    {
       key: 'sampling',
       label: '最新采样',
       value: latestMetricTimestamp > 0 ? formatTime(latestMetricTimestamp) : '--',
@@ -113,7 +156,7 @@ export function Overview() {
   return (
     <div className="p-6 space-y-6">
       <section>
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
           {stats.map((item) => (
             <div key={item.key} className={`rounded-2xl border p-4 backdrop-blur-sm ${item.cardClassName}`}>
               <p className="text-xs uppercase tracking-[0.22em] text-slate-500">{item.label}</p>

--- a/packages/ui/tests/overview-detail-settings.test.tsx
+++ b/packages/ui/tests/overview-detail-settings.test.tsx
@@ -292,6 +292,89 @@ describe('overview detail settings', () => {
     });
   });
 
+  it('shows internet reachability card with placeholder when no data', async () => {
+    const transport = createMockTransport();
+    const server = createServer();
+
+    useStore.setState({
+      servers: [server],
+      statuses: new Map([[server.id, createStatus(server.id)]]),
+      latestMetrics: new Map([[server.id, createMetricsSnapshot(server.id)]]),
+    });
+
+    renderWithProviders(<Overview />, transport);
+
+    // Card label should be visible
+    expect(screen.getByText('外网连通')).toBeTruthy();
+    // No internet data → value should be '--'
+    expect(screen.getByText('等待节点上报外网探测数据')).toBeTruthy();
+  });
+
+  it('shows internet reachability card with all-reachable state', async () => {
+    const transport = createMockTransport();
+    const server = createServer();
+    const metrics = createMetricsSnapshot(server.id);
+    metrics.network.internetReachable = true;
+    metrics.network.internetLatencyMs = 25;
+    metrics.network.internetProbeTarget = '1.1.1.1:443';
+    metrics.network.internetProbeCheckedAt = Date.now();
+
+    useStore.setState({
+      servers: [server],
+      statuses: new Map([[server.id, createStatus(server.id)]]),
+      latestMetrics: new Map([[server.id, metrics]]),
+    });
+
+    renderWithProviders(<Overview />, transport);
+
+    const internetLabel = screen.getByText('外网连通');
+    expect(internetLabel).toBeTruthy();
+    // Find the specific card container for internet reachability
+    const internetCard = internetLabel.closest('.rounded-2xl') as HTMLElement;
+    expect(internetCard).toBeTruthy();
+    expect(within(internetCard).getByText('所有上报节点外网畅通')).toBeTruthy();
+    // Badges render as "可达 1" and "不可达 0" (label + value in one span).
+    // Both contain "可达" as a substring, so we use getAllByText for the
+    // positive match and getByText with a start-anchor for the negative.
+    const reachBadges = within(internetCard).getAllByText(/可达/);
+    expect(reachBadges.length).toBe(2); // "可达 1" + "不可达 0"
+    expect(within(internetCard).getByText(/^不可达/)).toBeTruthy();
+  });
+
+  it('shows internet reachability card with unreachable node', async () => {
+    const transport = createMockTransport();
+    const serverA = createServer({ id: 'srv-a', name: 'node-a' });
+    const serverB = createServer({ id: 'srv-b', name: 'node-b' });
+    const metricsA = createMetricsSnapshot('srv-a');
+    metricsA.network.internetReachable = true;
+    metricsA.network.internetLatencyMs = 10;
+    metricsA.network.internetProbeTarget = '1.1.1.1:443';
+    metricsA.network.internetProbeCheckedAt = Date.now();
+    const metricsB = createMetricsSnapshot('srv-b');
+    metricsB.network.internetReachable = false;
+    metricsB.network.internetLatencyMs = null;
+    metricsB.network.internetProbeTarget = '1.1.1.1:443';
+    metricsB.network.internetProbeCheckedAt = Date.now();
+
+    useStore.setState({
+      servers: [serverA, serverB],
+      statuses: new Map([
+        ['srv-a', createStatus('srv-a')],
+        ['srv-b', createStatus('srv-b')],
+      ]),
+      latestMetrics: new Map([
+        ['srv-a', metricsA],
+        ['srv-b', metricsB],
+      ]),
+    });
+
+    renderWithProviders(<Overview />, transport);
+
+    expect(screen.getByText('外网连通')).toBeTruthy();
+    expect(screen.getByText('1/2')).toBeTruthy();
+    expect(screen.getByText('1 个节点外网不可达')).toBeTruthy();
+  });
+
   it('shows distinct source and presence badges on overview cards', async () => {
     const transport = createMockTransport();
     const agentServer = createServer();


### PR DESCRIPTION
## Summary

在 Overview 总状态栏新增「外网连通」汇总卡片，跨所有节点聚合上报的外网可达情况。数据链路贯穿 4 层：

- **packages/core**: `NetworkMetrics` 新增 4 个可选字段 `internetReachable / internetLatencyMs / internetProbeTarget / internetProbeCheckedAt`，向后兼容（字段全部 optional）
- **agent (Python)**: 新增 `pmeow.collector.internet`，默认对 `1.1.1.1:443,8.8.8.8:443` 发 TCP 连接（非 ICMP，避免防火墙/权限问题），用单调时钟 TTL 缓存结果（默认 30s），避免每次采样都打探测目标；通过环境变量 `PMEOW_INTERNET_PROBE_TARGETS / _TIMEOUT / _INTERVAL` 可配
- **packages/core SSH 采集器**: 在同一次远端 exec 里组合 `/proc/net/dev` 与 `bash /dev/tcp` + `time -p` 探针（以 `---PROBE---` marker 分段），无需远端安装任何额外工具
- **packages/ui Overview**: 新卡片位于「待处理风险」与「最新采样」之间，全部可达时显示 emerald 配色、出现不可达时 rose 配色、无数据时中性配色；stats grid 在 xl 断点扩至 5 列

序列化约定：当 Agent 未运行探针时，`MetricsSnapshot.to_dict()` 会把 4 个 internet 字段从 `network` 子 dict 中剥掉（而非写 null），对应 TS 侧的 `undefined` 语义，老客户端无感知。

## 分层提交

- \`feat(core)\`: NetworkMetrics 新增可选字段
- \`feat(agent)\`: 新增 InternetProbe + daemon/snapshot 集成 + 单测
- \`feat(web/ssh)\`: SSH 采集器组合探测脚本 + parseProbeSection 导出
- \`feat(ui)\`: Overview 外网连通汇总卡
- 另附 \`agent: non-destructive Windows compatibility\`（此前在 fork 上独立推过，一并带过来，便于 upstream 同步）及 \`.gitignore\` 忽略 CLAUDE.md

## Test plan

- [x] \`pnpm test:core\` — 163 passed（含 10 个新增 ssh-network-collector 测试）
- [x] \`pnpm test:web\` — 50 passed
- [x] \`pnpm --filter @monitor/ui test\` — 71 passed（含 3 个 Overview 外网卡片测试）
- [x] \`cd agent && pytest -v\` — 168 passed（含 14 个 collector/test_internet.py + 3 个 test_models.py 新增）
- [x] \`pnpm typecheck:core\` / \`typecheck:web\` / \`@monitor/ui typecheck\`
- [x] 手动验证：在连通/断网两种节点上核对 Overview 卡片颜色切换