### PR TITLE
fix(agent/test): patch gpu attribution helpers instead of builtins.open

### DIFF
--- a/agent/tests/collector/test_gpu.py
+++ b/agent/tests/collector/test_gpu.py
@@ -226,7 +226,17 @@ class TestAttributionUnknownProcess:
     def test_proc_not_readable(self):
         proc = GpuProcessInfo(pid=7777, gpu_index=1, used_memory_mb=512.0, process_name="")
 
-        with patch("builtins.open", side_effect=OSError("Permission denied")):
+        # Simulate both /proc read and the psutil fallback failing to identify
+        # the owning user. Patch the helpers at the function level (returning
+        # None, the value the real helpers yield when they catch their own
+        # OSError) rather than patching builtins.open, which would also break
+        # psutil's unrelated internal /proc reads and raise before the
+        # attribution code gets a chance to bucket the process as unknown.
+        with patch(
+            "pmeow.collector.gpu_attribution._read_proc_uid", return_value=None,
+        ), patch(
+            "pmeow.collector.gpu_attribution._get_process_username", return_value=None,
+        ):
             summary = attribute_gpu_processes(
                 gpu_processes=[proc],
                 running_tasks=[],


### PR DESCRIPTION
## Summary

`TestAttributionUnknownProcess.test_proc_not_readable` is currently failing on `main` (CI run [24129493856](https://github.com/huan-yp/PMEOW/actions/runs/24129493856) after PR #13 merged).

Root cause: the test patched `builtins.open` globally to simulate an unreadable `/proc` entry, but the attribution path falls back to `psutil.Process(pid).username()` when `_read_proc_uid` returns `None`. psutil itself opens `/proc/<pid>/stat` internally, so the broad `builtins.open` patch raises `OSError` out of psutil before the attribution code ever reaches the unknown-process branch — the test fails with an unhandled `OSError`.

```
pmeow/collector/gpu_attribution.py:151: in attribute_gpu_processes
    username = _get_process_username(proc.pid)
pmeow/collector/gpu_attribution.py:71: in _get_process_username
    return psutil.Process(pid).username()
...
psutil/_common.py:682: in open_binary
    return open(fname, "rb", ...)  ← intercepted by global mock
E   OSError: Permission denied
```

## Fix

Patch `_read_proc_uid` and `_get_process_username` at the function level to return `None`, mirroring what the real helpers return when they catch their own `OSError`. Execution now falls through to the unknown bucket without disrupting psutil's unrelated internal `/proc` reads.

## Test plan

- [x] `pytest tests/collector/test_gpu.py` — 15 passed (was 14 passed / 1 failed on main)
- [x] `pytest tests/collector/test_gpu.py::TestAttributionUnknownProcess -v` — both tests pass