### PR TITLE
fix(ui): remove misleading unit suffix from refresh interval label

### DIFF
--- a/packages/ui/src/pages/Settings.tsx
+++ b/packages/ui/src/pages/Settings.tsx
@@ -54,7 +54,7 @@ export function Settings() {
         <div className="bg-dark-card border border-dark-border rounded-lg p-4">
           <h3 className="text-sm font-medium text-slate-300 mb-3">数据采集</h3>
           <div>
-            <label htmlFor="refreshIntervalMs" className="text-xs text-slate-500 block mb-1">刷新间隔 (毫秒)</label>
+            <label htmlFor="refreshIntervalMs" className="text-xs text-slate-500 block mb-1">刷新间隔</label>
             <div className="flex items-center gap-3">
               <input id="refreshIntervalMs" type="range" min={1000} max={30000} step={1000}
                 value={local.refreshIntervalMs}


### PR DESCRIPTION
The slider label said "刷新间隔 (毫秒)" but the displayed value is already converted to seconds (e.g. "5s"), matching the backend setInterval semantics (5_000 ms = 5 s).

一个很小的修改，只修改了setting页面前端刷新间隔的label文本。
实现上单位应该是ms，滑动条右侧显示s，而文本显示单位为“（毫秒）”。 索性把文本中的毫秒删了。直接写“刷新间隔”。