### PR TITLE
Upgrade person mobile UI with secondary pages, notification tab, and detail navigation

### DIFF
--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -7,6 +7,7 @@ import {
   type BottomTabScreenProps,
 } from '@react-navigation/bottom-tabs';
 import { SafeAreaProvider, SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import Svg, { Circle, Path } from 'react-native-svg';
 import {
   createNativeStackNavigator,
   type NativeStackNavigationProp,
@@ -16,9 +17,10 @@ import type { Alert as PmeowAlert, SecurityEvent, Server } from '@pmeow/app-comm
 import { ADMIN_TAB_ROUTES, PERSON_TAB_ROUTES } from './app/navigation';
 import { styles } from './app/styles';
 import { useServerGpuHistory } from './app/useServerGpuHistory';
-import { AuthenticatedShell, SectionCard } from './components/common';
+import { AuthenticatedShell, RefreshableScrollView, SectionCard } from './components/common';
 import { setNativeAppInForeground } from './lib/native-notifications';
 import type { MobileHomeView } from './lib/preferences';
+import type { MainTabIconId } from './app/navigation';
 import {
   AdminAlertDetailView,
   AdminAlertsScreen,
@@ -27,7 +29,7 @@ import {
   AdminSecurityEventDetailView,
 } from './screens/AdminScreens';
 import { ConnectionScreen } from './screens/ConnectionScreen';
-import { PersonHomeScreen, PersonTasksScreen } from './screens/PersonScreens';
+import { PersonHomeScreen, PersonNotificationsScreen, PersonTasksScreen } from './screens/PersonScreens';
 import { PersonTaskDetailScreen } from './screens/PersonTaskDetailScreen';
 import { ServerDetailScreen } from './screens/ServerDetailScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
@@ -51,6 +53,7 @@ type AdminStackParamList = {
 type PersonTabParamList = {
   Resources: undefined;
   MyTasks: undefined;
+  Notifications: undefined;
   PersonSettings: undefined;
 };
 
@@ -98,6 +101,97 @@ const tabScreenOptions = {
   },
 };
 
+function MainTabIcon(props: { icon: MainTabIconId; color: string; size: number }) {
+  const commonProps = {
+    stroke: props.color,
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    fill: 'none',
+  };
+
+  const children = (() => {
+    if (props.icon === 'overview') {
+      return (
+        <>
+          <Path {...commonProps} d="M4 13h6v7H4z" />
+          <Path {...commonProps} d="M14 4h6v16h-6z" />
+          <Path {...commonProps} d="M4 4h6v5H4z" />
+        </>
+      );
+    }
+
+    if (props.icon === 'nodes') {
+      return (
+        <>
+          <Path {...commonProps} d="M7 8h10M7 16h10M12 8v8" />
+          <Circle {...commonProps} cx={7} cy={8} r={3} />
+          <Circle {...commonProps} cx={17} cy={8} r={3} />
+          <Circle {...commonProps} cx={7} cy={16} r={3} />
+          <Circle {...commonProps} cx={17} cy={16} r={3} />
+        </>
+      );
+    }
+
+    if (props.icon === 'alerts') {
+      return (
+        <>
+          <Path {...commonProps} d="M12 4 3.5 19h17z" />
+          <Path {...commonProps} d="M12 9v4" />
+          <Path {...commonProps} d="M12 17h.01" />
+        </>
+      );
+    }
+
+    if (props.icon === 'settings') {
+      return (
+        <>
+          <Path {...commonProps} d="M5 7h14M5 12h14M5 17h14" />
+          <Path {...commonProps} d="M9 5v4M15 10v4M11 15v4" />
+        </>
+      );
+    }
+
+    if (props.icon === 'resources') {
+      return (
+        <>
+          <Path {...commonProps} d="M4 6c0-1.7 3.6-3 8-3s8 1.3 8 3-3.6 3-8 3-8-1.3-8-3z" />
+          <Path {...commonProps} d="M4 6v6c0 1.7 3.6 3 8 3s8-1.3 8-3V6" />
+          <Path {...commonProps} d="M4 12v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" />
+        </>
+      );
+    }
+
+    if (props.icon === 'notifications') {
+      return (
+        <>
+          <Path {...commonProps} d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <Path {...commonProps} d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Path {...commonProps} d="M5 5h14v14H5z" />
+        <Path {...commonProps} d="m8 12 2.5 2.5L16 9" />
+      </>
+    );
+  })();
+
+  return (
+    <Svg width={props.size} height={props.size} viewBox="0 0 24 24">
+      {children}
+    </Svg>
+  );
+}
+
+function createTabIconRenderer(icon: MainTabIconId) {
+  return ({ color, size }: { focused: boolean; color: string; size: number }) => (
+    <MainTabIcon icon={icon} color={color} size={size} />
+  );
+}
+
 function RoleTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
   const insets = useSafeAreaInsets();
 
@@ -112,6 +206,8 @@ function RoleTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
           : typeof options.title === 'string'
             ? options.title
             : route.name;
+        const tintColor = focused ? '#f3f8fc' : '#8ea5b8';
+        const icon = options.tabBarIcon?.({ focused, color: tintColor, size: 20 });
 
         return (
           <Pressable
@@ -131,6 +227,7 @@ function RoleTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
               }
             }}
           >
+            {icon ? <View style={styles.roleTabIcon}>{icon}</View> : null}
             <Text style={[styles.roleTabLabel, focused ? styles.roleTabLabelActive : null]}>{label}</Text>
           </Pressable>
         );
@@ -183,11 +280,11 @@ function ScreenFrame(props: {
 function MissingServerScreen(props: { onRefresh: () => Promise<void> }) {
   return (
     <ScreenFrame title="机器详情" identityLabel="机器详情" onRefresh={props.onRefresh}>
-      <View style={styles.screenContent}>
+      <RefreshableScrollView contentContainerStyle={styles.screenContent}>
         <SectionCard title="无法显示机器详情" description="该机器可能已不在当前可见范围内。">
-          <Text style={styles.emptyText}>请返回列表刷新后重试。</Text>
+          <Text style={styles.emptyText}>请返回列表下拉刷新后重试。</Text>
         </SectionCard>
-      </View>
+      </RefreshableScrollView>
     </ScreenFrame>
   );
 }
@@ -199,11 +296,11 @@ function MissingAdminRecordScreen(props: {
 }) {
   return (
     <ScreenFrame title={props.title} identityLabel={props.title} onRefresh={props.onRefresh}>
-      <View style={styles.screenContent}>
+      <RefreshableScrollView contentContainerStyle={styles.screenContent}>
         <SectionCard title={props.title} description={props.description}>
-          <Text style={styles.emptyText}>请返回列表刷新后重试。</Text>
+          <Text style={styles.emptyText}>请返回列表下拉刷新后重试。</Text>
         </SectionCard>
-      </View>
+      </RefreshableScrollView>
     </ScreenFrame>
   );
 }
@@ -307,13 +404,14 @@ function AdminSettingsTab() {
 
 function AdminTabsNavigator() {
   const labels = Object.fromEntries(ADMIN_TAB_ROUTES.map((route) => [route.name, route.label]));
+  const icons = Object.fromEntries(ADMIN_TAB_ROUTES.map((route) => [route.name, route.icon]));
 
   return (
     <AdminTabs.Navigator backBehavior="initialRoute" screenOptions={tabScreenOptions} tabBar={(props) => <RoleTabBar {...props} />}>
-      <AdminTabs.Screen name="OpsOverview" component={AdminOpsOverviewTab} options={{ tabBarLabel: labels.OpsOverview }} />
-      <AdminTabs.Screen name="Nodes" component={AdminNodesTab} options={{ tabBarLabel: labels.Nodes }} />
-      <AdminTabs.Screen name="Alerts" component={AdminAlertsTab} options={{ tabBarLabel: labels.Alerts }} />
-      <AdminTabs.Screen name="AdminSettings" component={AdminSettingsTab} options={{ tabBarLabel: labels.AdminSettings }} />
+      <AdminTabs.Screen name="OpsOverview" component={AdminOpsOverviewTab} options={{ tabBarLabel: labels.OpsOverview, tabBarIcon: createTabIconRenderer(icons.OpsOverview) }} />
+      <AdminTabs.Screen name="Nodes" component={AdminNodesTab} options={{ tabBarLabel: labels.Nodes, tabBarIcon: createTabIconRenderer(icons.Nodes) }} />
+      <AdminTabs.Screen name="Alerts" component={AdminAlertsTab} options={{ tabBarLabel: labels.Alerts, tabBarIcon: createTabIconRenderer(icons.Alerts) }} />
+      <AdminTabs.Screen name="AdminSettings" component={AdminSettingsTab} options={{ tabBarLabel: labels.AdminSettings, tabBarIcon: createTabIconRenderer(icons.AdminSettings) }} />
     </AdminTabs.Navigator>
   );
 }
@@ -322,6 +420,7 @@ function ServerDetailRoute(props: {
   serverId: string;
   isAdmin: boolean;
   onBack: () => void;
+  onSelectTask?: (taskId: string) => void;
 }) {
   const context = useMobileContext();
   const selectedServer = useMemo(
@@ -363,6 +462,7 @@ function ServerDetailRoute(props: {
         onBack={props.onBack}
         onToggleSubscription={() => context.toggleIdleServerSubscription(selectedServer.id)}
         onSaveSubscriptionRule={(rule) => context.updateIdleServerRule(selectedServer.id, rule)}
+        onSelectTask={props.onSelectTask}
       />
     </AuthenticatedShell>
   );
@@ -453,6 +553,7 @@ function PersonResourcesTab(props: BottomTabScreenProps<PersonTabParamList, 'Res
   const context = useMobileContext();
   const personName = getPersonName(context);
   const stackNavigation = props.navigation.getParent<NativeStackNavigationProp<PersonStackParamList>>();
+  const subscribedServerCount = Object.keys(context.notificationSettings.person.idleServerRules).length;
 
   return (
     <ScreenFrame title="资源" identityLabel={`普通用户 · ${personName}`} onRefresh={context.refreshOverview}>
@@ -462,10 +563,27 @@ function PersonResourcesTab(props: BottomTabScreenProps<PersonTabParamList, 'Res
         statuses={context.statuses}
         latestMetrics={context.latestMetrics}
         personTasks={context.personTasks}
-        recentTaskEvents={context.recentTaskEvents}
-        notificationInbox={context.notificationInbox}
         homeView={context.notificationSettings.home.personView}
         onChangeHomeView={(view: MobileHomeView) => context.setHomeView('person', view)}
+        onSelectServer={(serverId) => stackNavigation?.navigate('PersonServerDetail', { serverId })}
+        subscribedServerCount={subscribedServerCount}
+        onNavigateToTasks={() => props.navigation.navigate('MyTasks')}
+        onNavigateToNotifications={() => props.navigation.navigate('Notifications')}
+      />
+    </ScreenFrame>
+  );
+}
+
+function PersonNotificationsTab(props: BottomTabScreenProps<PersonTabParamList, 'Notifications'>) {
+  const context = useMobileContext();
+  const personName = getPersonName(context);
+  const stackNavigation = props.navigation.getParent<NativeStackNavigationProp<PersonStackParamList>>();
+
+  return (
+    <ScreenFrame title="通知" identityLabel={`普通用户 · ${personName}`} onRefresh={context.refreshOverview}>
+      <PersonNotificationsScreen
+        recentTaskEvents={context.recentTaskEvents}
+        notificationInbox={context.notificationInbox}
         onSelectServer={(serverId) => stackNavigation?.navigate('PersonServerDetail', { serverId })}
       />
     </ScreenFrame>
@@ -528,12 +646,14 @@ function PersonSettingsTab() {
 
 function PersonTabsNavigator() {
   const labels = Object.fromEntries(PERSON_TAB_ROUTES.map((route) => [route.name, route.label]));
+  const icons = Object.fromEntries(PERSON_TAB_ROUTES.map((route) => [route.name, route.icon]));
 
   return (
     <PersonTabs.Navigator backBehavior="initialRoute" screenOptions={tabScreenOptions} tabBar={(props) => <RoleTabBar {...props} />}>
-      <PersonTabs.Screen name="Resources" component={PersonResourcesTab} options={{ tabBarLabel: labels.Resources }} />
-      <PersonTabs.Screen name="MyTasks" component={PersonTasksTab} options={{ tabBarLabel: labels.MyTasks }} />
-      <PersonTabs.Screen name="PersonSettings" component={PersonSettingsTab} options={{ tabBarLabel: labels.PersonSettings }} />
+      <PersonTabs.Screen name="Resources" component={PersonResourcesTab} options={{ tabBarLabel: labels.Resources, tabBarIcon: createTabIconRenderer(icons.Resources) }} />
+      <PersonTabs.Screen name="MyTasks" component={PersonTasksTab} options={{ tabBarLabel: labels.MyTasks, tabBarIcon: createTabIconRenderer(icons.MyTasks) }} />
+      <PersonTabs.Screen name="Notifications" component={PersonNotificationsTab} options={{ tabBarLabel: labels.Notifications, tabBarIcon: createTabIconRenderer(icons.Notifications) }} />
+      <PersonTabs.Screen name="PersonSettings" component={PersonSettingsTab} options={{ tabBarLabel: labels.PersonSettings, tabBarIcon: createTabIconRenderer(icons.PersonSettings) }} />
     </PersonTabs.Navigator>
   );
 }
@@ -544,6 +664,7 @@ function PersonServerDetailScreen(props: NativeStackScreenProps<PersonStackParam
       serverId={props.route.params.serverId}
       isAdmin={false}
       onBack={() => props.navigation.goBack()}
+      onSelectTask={(taskId) => props.navigation.navigate('PersonTaskDetail', { taskId })}
     />
   );
 }

--- a/apps/mobile/src/app/navigation.ts
+++ b/apps/mobile/src/app/navigation.ts
@@ -1,23 +1,28 @@
 export type AdminTabRouteName = 'OpsOverview' | 'Nodes' | 'Alerts' | 'AdminSettings';
-export type PersonTabRouteName = 'Resources' | 'MyTasks' | 'PersonSettings';
+export type PersonTabRouteName = 'Resources' | 'MyTasks' | 'Notifications' | 'PersonSettings';
 export type AdminDetailRouteName = 'AdminServerDetail' | 'AdminAlertDetail' | 'AdminSecurityEventDetail';
 export type PersonDetailRouteName = 'PersonServerDetail' | 'PersonTaskDetail';
+export type MainTabIconId = 'overview' | 'nodes' | 'alerts' | 'settings' | 'resources' | 'tasks' | 'notifications';
 export type AdminAlertSecondaryPageId = 'activeAlerts' | 'securityEvents';
 export type AdminSettingsSecondaryPageId = 'localNotifications' | 'notificationInbox' | 'connection';
+export type PersonTaskSecondaryPageId = 'inProgress' | 'completed' | 'all';
+export type PersonNotificationSecondaryPageId = 'taskEvents' | 'notificationInbox';
+export type PersonSettingsSecondaryPageId = 'localNotifications' | 'notificationInbox' | 'connection';
 export type ServerDetailSecondaryPageId = 'overview' | 'realtime' | 'disk' | 'vram' | 'tasks';
 export const SERVER_DETAIL_TAB_BLOCK_SIZE = 3;
 
-export const ADMIN_TAB_ROUTES: Array<{ name: AdminTabRouteName; label: string }> = [
-  { name: 'OpsOverview', label: '总览' },
-  { name: 'Nodes', label: '节点' },
-  { name: 'Alerts', label: '告警' },
-  { name: 'AdminSettings', label: '设置' },
+export const ADMIN_TAB_ROUTES: Array<{ name: AdminTabRouteName; label: string; icon: MainTabIconId }> = [
+  { name: 'OpsOverview', label: '总览', icon: 'overview' },
+  { name: 'Nodes', label: '节点', icon: 'nodes' },
+  { name: 'Alerts', label: '告警', icon: 'alerts' },
+  { name: 'AdminSettings', label: '设置', icon: 'settings' },
 ];
 
-export const PERSON_TAB_ROUTES: Array<{ name: PersonTabRouteName; label: string }> = [
-  { name: 'Resources', label: '资源' },
-  { name: 'MyTasks', label: '我的任务' },
-  { name: 'PersonSettings', label: '设置' },
+export const PERSON_TAB_ROUTES: Array<{ name: PersonTabRouteName; label: string; icon: MainTabIconId }> = [
+  { name: 'Resources', label: '资源', icon: 'resources' },
+  { name: 'MyTasks', label: '我的任务', icon: 'tasks' },
+  { name: 'Notifications', label: '通知', icon: 'notifications' },
+  { name: 'PersonSettings', label: '设置', icon: 'settings' },
 ];
 
 export const ADMIN_DETAIL_ROUTES: Array<{ name: AdminDetailRouteName }> = [
@@ -37,6 +42,23 @@ export const ADMIN_ALERT_SECONDARY_PAGES: Array<{ id: AdminAlertSecondaryPageId;
 ];
 
 export const ADMIN_SETTINGS_SECONDARY_PAGES: Array<{ id: AdminSettingsSecondaryPageId; label: string }> = [
+  { id: 'localNotifications', label: '本地通知' },
+  { id: 'notificationInbox', label: '通知记录' },
+  { id: 'connection', label: '当前连接' },
+];
+
+export const PERSON_TASK_SECONDARY_PAGES: Array<{ id: PersonTaskSecondaryPageId; label: string }> = [
+  { id: 'inProgress', label: '进行中' },
+  { id: 'completed', label: '已结束' },
+  { id: 'all', label: '全部' },
+];
+
+export const PERSON_NOTIFICATION_SECONDARY_PAGES: Array<{ id: PersonNotificationSecondaryPageId; label: string }> = [
+  { id: 'taskEvents', label: '任务事件' },
+  { id: 'notificationInbox', label: '通知记录' },
+];
+
+export const PERSON_SETTINGS_SECONDARY_PAGES: Array<{ id: PersonSettingsSecondaryPageId; label: string }> = [
   { id: 'localNotifications', label: '本地通知' },
   { id: 'notificationInbox', label: '通知记录' },
   { id: 'connection', label: '当前连接' },
@@ -90,8 +112,8 @@ export const MOBILE_INFORMATION_MAP = {
   person: {
     machineSummary: 'Resources',
     gpuIdleMachineView: 'Resources',
-    recentTaskEvents: 'Resources',
-    notificationInbox: 'Resources',
+    recentTaskEvents: 'Notifications',
+    notificationInbox: 'Notifications',
     personTasks: 'MyTasks',
     cancelTask: 'MyTasks',
     notificationSettings: 'PersonSettings',

--- a/apps/mobile/src/app/styles.ts
+++ b/apps/mobile/src/app/styles.ts
@@ -86,19 +86,6 @@ export const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 20,
   },
-  refreshButton: {
-    minWidth: 88,
-    borderRadius: 20,
-    backgroundColor: '#16324b',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 16,
-  },
-  refreshButtonText: {
-    color: '#dce9f4',
-    fontSize: 14,
-    fontWeight: '700',
-  },
   card: {
     borderRadius: 18,
     padding: 20,
@@ -852,13 +839,20 @@ export const styles = StyleSheet.create({
   },
   roleTabItem: {
     flex: 1,
-    minHeight: 42,
+    minHeight: 48,
     borderRadius: 14,
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 3,
   },
   roleTabItemActive: {
     backgroundColor: '#12304a',
+  },
+  roleTabIcon: {
+    width: 20,
+    height: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   roleTabLabel: {
     color: '#8ea5b8',
@@ -939,17 +933,6 @@ export const styles = StyleSheet.create({
     color: '#a8bccd',
     fontSize: 13,
     fontWeight: '600',
-  },
-  compactRefreshButton: {
-    borderRadius: 14,
-    backgroundColor: '#16324b',
-    paddingHorizontal: 14,
-    paddingVertical: 6,
-  },
-  compactRefreshText: {
-    color: '#dce9f4',
-    fontSize: 12,
-    fontWeight: '700',
   },
   gpuIdleBar: {
     flexDirection: 'row',

--- a/apps/mobile/src/components/common.tsx
+++ b/apps/mobile/src/components/common.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   Animated,
   LayoutAnimation,
   Platform,
   Pressable,
+  RefreshControl,
   ScrollView,
   Text,
   UIManager,
@@ -12,6 +13,7 @@ import {
   type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
+  type ScrollViewProps,
 } from 'react-native';
 import PagerView from 'react-native-pager-view';
 import { indexToTab, tabToIndex } from '../app/constants';
@@ -38,6 +40,33 @@ import { ServerCardVisuals } from './monitoring';
 
 if (Platform.OS === 'android') {
   UIManager.setLayoutAnimationEnabledExperimental?.(true);
+}
+
+const PullToRefreshContext = createContext<{
+  refreshing: boolean;
+  onRefresh: () => Promise<void>;
+} | null>(null);
+
+export function RefreshableScrollView(props: ScrollViewProps & { children: ReactNode }) {
+  const refreshContext = useContext(PullToRefreshContext);
+  const { children, ...scrollProps } = props;
+
+  return (
+    <ScrollView
+      {...scrollProps}
+      refreshControl={refreshContext ? (
+        <RefreshControl
+          refreshing={refreshContext.refreshing}
+          onRefresh={() => void refreshContext.onRefresh()}
+          tintColor="#86d5ff"
+          colors={['#86d5ff']}
+          progressBackgroundColor="#0d1d2c"
+        />
+      ) : undefined}
+    >
+      {children}
+    </ScrollView>
+  );
 }
 
 export function SectionCard(props: {
@@ -531,14 +560,14 @@ export function TaskRow(props: {
   );
 }
 
-export function QueueTaskRow(props: { task: TaskInfo }) {
+export function QueueTaskRow(props: { task: TaskInfo; onPress?: () => void }) {
   const requestedVramText = formatTaskRequestedVram(props.task);
 
   return (
-    <View style={styles.eventRow}>
+    <Pressable style={styles.eventRowCard} disabled={!props.onPress} onPress={props.onPress}>
       <Text style={styles.eventTitle}>{formatQueueTaskStatus(props.task.status)} · {props.task.command}</Text>
       <Text style={styles.eventMeta}>{props.task.user} · VRAM {requestedVramText} · {formatTimestamp(props.task.createdAt)}</Text>
-    </View>
+    </Pressable>
   );
 }
 
@@ -709,36 +738,32 @@ export function AuthenticatedShell(props: {
   tabs?: ReactNode;
 }) {
   return (
-    <View style={styles.shell}>
-      {props.compact ? (
-        <>
-          <View style={styles.compactHeaderRow}>
-            <Text style={styles.compactHeaderLabel}>{props.identityLabel ?? props.subtitle}</Text>
-            <Pressable style={styles.compactRefreshButton} onPress={() => void props.onRefresh()}>
-              <Text style={styles.compactRefreshText}>{props.refreshing ? '刷新中...' : '刷新'}</Text>
-            </Pressable>
-          </View>
-          {props.error ? (
+    <PullToRefreshContext.Provider value={{ refreshing: props.refreshing, onRefresh: props.onRefresh }}>
+      <View style={styles.shell}>
+        {props.compact ? (
+          <>
             <View style={styles.compactHeaderRow}>
-              <Text style={styles.errorText}>{props.error}</Text>
+              <Text style={styles.compactHeaderLabel}>{props.identityLabel ?? props.subtitle}</Text>
             </View>
-          ) : null}
-        </>
-      ) : (
-        <View style={styles.shellHeader}>
-          <View style={styles.heroCompact}>
-            <Text style={styles.kicker}>PMEOW MOBILE</Text>
-            <Text style={styles.shellTitle}>{props.title}</Text>
-            <Text style={styles.shellSubtitle}>{props.subtitle}</Text>
-            {props.error ? <Text style={styles.errorText}>{props.error}</Text> : null}
+            {props.error ? (
+              <View style={styles.compactHeaderRow}>
+                <Text style={styles.errorText}>{props.error}</Text>
+              </View>
+            ) : null}
+          </>
+        ) : (
+          <View style={styles.shellHeader}>
+            <View style={styles.heroCompact}>
+              <Text style={styles.kicker}>PMEOW MOBILE</Text>
+              <Text style={styles.shellTitle}>{props.title}</Text>
+              <Text style={styles.shellSubtitle}>{props.subtitle}</Text>
+              {props.error ? <Text style={styles.errorText}>{props.error}</Text> : null}
+            </View>
           </View>
-          <Pressable style={styles.refreshButton} onPress={() => void props.onRefresh()}>
-            <Text style={styles.refreshButtonText}>{props.refreshing ? '刷新中...' : '刷新'}</Text>
-          </Pressable>
-        </View>
-      )}
-      <View style={styles.screenWrap}>{props.children}</View>
-      {props.tabs}
-    </View>
+        )}
+        <View style={styles.screenWrap}>{props.children}</View>
+        {props.tabs}
+      </View>
+    </PullToRefreshContext.Provider>
   );
 }

--- a/apps/mobile/src/screens/AdminScreens.tsx
+++ b/apps/mobile/src/screens/AdminScreens.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 import type {
   Alert,
   SecurityEvent,
@@ -17,7 +17,7 @@ import {
 } from '../app/formatters';
 import { ADMIN_ALERT_SECONDARY_PAGES, type AdminAlertSecondaryPageId } from '../app/navigation';
 import { styles } from '../app/styles';
-import { ExpandableList, MachineViewPager, PageSection, SecondarySwipeView } from '../components/common';
+import { ExpandableList, MachineViewPager, PageSection, RefreshableScrollView, SecondarySwipeView } from '../components/common';
 import type { MobileHomeView } from '../lib/preferences';
 
 export function AdminOpsOverviewScreen(props: {
@@ -37,8 +37,8 @@ export function AdminOpsOverviewScreen(props: {
   const onlineRatio = props.serverCount === 0 ? 0 : Math.round((props.onlineCount / props.serverCount) * 100);
 
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
-      <PageSection title="当前概览" description={props.realtimeConnected ? '实时连接已建立。' : '实时连接未建立，建议手动刷新。'}>
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
+      <PageSection title="当前概览" description={props.realtimeConnected ? '实时连接已建立。' : '实时连接未建立，建议下拉刷新。'}>
         <View style={styles.dashboardHero}>
           <View style={styles.dashboardHeroHeader}>
             <View>
@@ -104,7 +104,7 @@ export function AdminOpsOverviewScreen(props: {
           )}
         </View>
       </PageSection>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -117,7 +117,7 @@ export function AdminNodesScreen(props: {
   onSelectServer: (serverId: string) => void;
 }) {
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
       <PageSection title="机器视图" description="左右滑动切换机器摘要和 GPU 空闲情况，点按机器摘要可展开状态信息。">
         <MachineViewPager
           view={props.homeView}
@@ -129,7 +129,7 @@ export function AdminNodesScreen(props: {
           onSelectServer={props.onSelectServer}
         />
       </PageSection>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -142,7 +142,7 @@ export function AdminAlertsScreen(props: {
   const [activePage, setActivePage] = useState<AdminAlertSecondaryPageId>('activeAlerts');
 
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
       <PageSection title="告警中心" description="按功能分组查看活动告警和未解决安全事件。">
         <SecondarySwipeView
           pages={ADMIN_ALERT_SECONDARY_PAGES}
@@ -191,7 +191,7 @@ export function AdminAlertsScreen(props: {
           )}
         />
       </PageSection>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -200,7 +200,7 @@ export function AdminAlertDetailView(props: {
   onBack: () => void;
 }) {
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
       <Pressable style={styles.detailBackButton} onPress={props.onBack}>
         <Text style={styles.detailBackButtonText}>返回</Text>
       </Pressable>
@@ -225,7 +225,7 @@ export function AdminAlertDetailView(props: {
           </View>
         </View>
       </PageSection>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -236,7 +236,7 @@ export function AdminSecurityEventDetailView(props: {
   const details = props.event.details;
 
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
       <Pressable style={styles.detailBackButton} onPress={props.onBack}>
         <Text style={styles.detailBackButtonText}>返回</Text>
       </Pressable>
@@ -262,6 +262,6 @@ export function AdminSecurityEventDetailView(props: {
           </View>
         </View>
       </PageSection>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }

--- a/apps/mobile/src/screens/PersonScreens.tsx
+++ b/apps/mobile/src/screens/PersonScreens.tsx
@@ -1,7 +1,9 @@
-import { ScrollView, Text, View } from 'react-native';
+import { useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
 import type { Server, ServerStatus, Task, TaskEvent, UnifiedReport } from '@pmeow/app-common';
 import type { NotificationInboxItem } from '../lib/notification-inbox';
 import { formatTaskEventLabel, formatTimestamp } from '../app/formatters';
+import { PERSON_NOTIFICATION_SECONDARY_PAGES, PERSON_TASK_SECONDARY_PAGES, type PersonNotificationSecondaryPageId, type PersonTaskSecondaryPageId } from '../app/navigation';
 import { styles } from '../app/styles';
 import type { MobileHomeView } from '../lib/preferences';
 import {
@@ -9,6 +11,8 @@ import {
   MachineViewPager,
   NotificationInboxSection,
   PageSection,
+  RefreshableScrollView,
+  SecondarySwipeView,
   TaskRow,
 } from '../components/common';
 
@@ -18,15 +22,50 @@ export function PersonHomeScreen(props: {
   statuses: Record<string, ServerStatus>;
   latestMetrics: Record<string, UnifiedReport>;
   personTasks: Task[];
-  recentTaskEvents: TaskEvent[];
-  notificationInbox: NotificationInboxItem[];
   homeView: MobileHomeView;
   onChangeHomeView: (view: MobileHomeView) => void;
   onSelectServer: (serverId: string) => void;
+  subscribedServerCount: number;
+  onNavigateToTasks: () => void;
+  onNavigateToNotifications: () => void;
 }) {
+  const onlineCount = props.servers.filter((server) => props.statuses[server.id]?.status === 'online').length;
+  const onlineRatio = props.servers.length === 0 ? 0 : Math.round((onlineCount / props.servers.length) * 100);
+  const taskCount = props.personTasks.length;
+
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
-      <PageSection title="机器视图" description="左右滑动切换机器摘要和 GPU 空闲情况，点按机器摘要可展开状态信息。">
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
+      <PageSection title="当前概览" description="当前机器总览、任务与订阅统计，左右滑动切换机器摘要和 GPU 空闲情况。">
+        <View style={styles.dashboardHero}>
+          <View style={styles.dashboardHeroHeader}>
+            <View>
+              <Text style={styles.dashboardHeroTitle}>机器健康度</Text>
+              <Text style={styles.dashboardHeroMeta}>在线 {onlineCount} / 可见 {props.servers.length}</Text>
+            </View>
+            <Text style={styles.dashboardHeroValue}>{onlineRatio}%</Text>
+          </View>
+          <View style={styles.dashboardProgressTrack}>
+            <View style={[styles.dashboardProgressFill, { width: `${onlineRatio}%` }]} />
+          </View>
+        </View>
+
+        <View style={styles.dashboardActionGrid}>
+          <Pressable style={styles.dashboardActionCard} onPress={props.onNavigateToTasks}>
+            <Text style={styles.dashboardActionLabel}>我的任务</Text>
+            <Text style={styles.dashboardActionValue}>{taskCount}</Text>
+            <Text style={styles.dashboardActionMeta}>
+              {taskCount > 0 ? `${props.personTasks.filter((t) => t.status === 'queued' || t.status === 'running').length} 个进行中` : '当前没有相关任务'}
+            </Text>
+          </Pressable>
+          <Pressable style={styles.dashboardActionCard} onPress={props.onNavigateToNotifications}>
+            <Text style={styles.dashboardActionLabel}>已订阅机器</Text>
+            <Text style={styles.dashboardActionValue}>{props.subscribedServerCount}</Text>
+            <Text style={styles.dashboardActionMeta}>
+              {props.subscribedServerCount > 0 ? '正在接收空闲提醒' : '尚未订阅任何机器'}
+            </Text>
+          </Pressable>
+        </View>
+
         <MachineViewPager
           view={props.homeView}
           onChangeView={props.onChangeHomeView}
@@ -37,30 +76,57 @@ export function PersonHomeScreen(props: {
           onSelectServer={props.onSelectServer}
         />
       </PageSection>
+    </RefreshableScrollView>
+  );
+}
 
-      <PageSection title="最近任务事件" description="与你可见范围相关的实时任务变更。">
-        {props.recentTaskEvents.length === 0 ? (
-          <Text style={styles.emptyText}>尚未收到任务实时事件。</Text>
-        ) : (
-          <ExpandableList
-            totalCount={props.recentTaskEvents.length}
-            initialVisibleCount={4}
-            renderItems={(expanded) => {
-              const visibleEvents = expanded ? props.recentTaskEvents : props.recentTaskEvents.slice(0, 4);
+export function PersonNotificationsScreen(props: {
+  recentTaskEvents: TaskEvent[];
+  notificationInbox: NotificationInboxItem[];
+  onSelectServer: (serverId: string) => void;
+}) {
+  const [activePage, setActivePage] = useState<PersonNotificationSecondaryPageId>('taskEvents');
 
-              return visibleEvents.map((event) => (
-                <View key={`${event.serverId}-${event.task.taskId}-${event.eventType}-${event.task.createdAt}`} style={styles.eventRow}>
-                  <Text style={styles.eventTitle}>{formatTaskEventLabel(event)} · {event.task.command}</Text>
-                  <Text style={styles.eventMeta}>{event.serverId} · {formatTimestamp(event.task.createdAt)}</Text>
-                </View>
-              ));
-            }}
-          />
-        )}
+  return (
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
+      <PageSection title="通知" description="与你可见范围相关的实时任务变更和系统通知。">
+        <SecondarySwipeView
+          pages={PERSON_NOTIFICATION_SECONDARY_PAGES}
+          activePage={activePage}
+          onChangePage={setActivePage}
+          renderPage={(page) => (
+            <View style={styles.sectionPanel}>
+              {page === 'taskEvents' ? (
+                props.recentTaskEvents.length === 0 ? (
+                  <Text style={styles.emptyText}>尚未收到任务实时事件。</Text>
+                ) : (
+                  <ExpandableList
+                    totalCount={props.recentTaskEvents.length}
+                    initialVisibleCount={5}
+                    renderItems={(expanded) => {
+                      const visibleEvents = expanded ? props.recentTaskEvents : props.recentTaskEvents.slice(0, 5);
+
+                      return visibleEvents.map((event) => (
+                        <Pressable
+                          key={`${event.serverId}-${event.task.taskId}-${event.eventType}-${event.task.createdAt}`}
+                          style={styles.eventRowCard}
+                          onPress={() => props.onSelectServer(event.serverId)}
+                        >
+                          <Text style={styles.eventTitle}>{formatTaskEventLabel(event)} · {event.task.command}</Text>
+                          <Text style={styles.eventMeta}>{event.serverId} · {formatTimestamp(event.task.createdAt)}</Text>
+                        </Pressable>
+                      ));
+                    }}
+                  />
+                )
+              ) : (
+                <NotificationInboxSection items={props.notificationInbox} initialVisibleCount={5} />
+              )}
+            </View>
+          )}
+        />
       </PageSection>
-
-      <NotificationInboxSection items={props.notificationInbox} initialVisibleCount={3} />
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }
 
@@ -70,30 +136,57 @@ export function PersonTasksScreen(props: {
   onSelectTask: (task: Task) => void;
   onCancelTask: (task: Task) => Promise<void>;
 }) {
+  const [activePage, setActivePage] = useState<PersonTaskSecondaryPageId>('all');
+
+  const inProgressTasks = props.personTasks.filter(
+    (t) => t.status === 'queued' || t.status === 'running',
+  );
+  const completedTasks = props.personTasks.filter(
+    (t) => t.status === 'succeeded' || t.status === 'failed' || t.status === 'cancelled' || t.status === 'abnormal',
+  );
+
+  const renderTaskList = (tasks: Task[]) => {
+    if (tasks.length === 0) {
+      return <Text style={styles.emptyText}>当前没有符合条件的任务。</Text>;
+    }
+    return (
+      <ExpandableList
+        totalCount={tasks.length}
+        initialVisibleCount={6}
+        renderItems={(expanded) => {
+          const visibleTasks = expanded ? tasks : tasks.slice(0, 6);
+          return visibleTasks.map((task) => (
+            <TaskRow
+              key={task.id}
+              task={task}
+              pending={props.pendingTaskId === task.id}
+              onPress={() => props.onSelectTask(task)}
+              onCancel={() => props.onCancelTask(task)}
+            />
+          ));
+        }}
+      />
+    );
+  };
+
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
-      <PageSection title="我的任务" description="点击任务可查看详情，仍可直接取消自己当前排队或运行中的任务。">
-        {props.personTasks.length === 0 ? (
-          <Text style={styles.emptyText}>当前没有与你绑定账号相关的任务。</Text>
-        ) : (
-          <ExpandableList
-            totalCount={props.personTasks.length}
-            initialVisibleCount={6}
-            renderItems={(expanded) => {
-              const visibleTasks = expanded ? props.personTasks : props.personTasks.slice(0, 6);
-              return visibleTasks.map((task) => (
-                <TaskRow
-                  key={task.id}
-                  task={task}
-                  pending={props.pendingTaskId === task.id}
-                  onPress={() => props.onSelectTask(task)}
-                  onCancel={() => props.onCancelTask(task)}
-                />
-              ));
-            }}
-          />
-        )}
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
+      <PageSection title="我的任务" description="按任务状态分组查看，点击任务可查看详情，仍可直接取消自己当前排队或运行中的任务。">
+        <SecondarySwipeView
+          pages={PERSON_TASK_SECONDARY_PAGES}
+          activePage={activePage}
+          onChangePage={setActivePage}
+          renderPage={(page) => (
+            <View style={styles.sectionPanel}>
+              {page === 'inProgress'
+                ? renderTaskList(inProgressTasks)
+                : page === 'completed'
+                  ? renderTaskList(completedTasks)
+                  : renderTaskList(props.personTasks)}
+            </View>
+          )}
+        />
       </PageSection>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }

--- a/apps/mobile/src/screens/PersonTaskDetailScreen.tsx
+++ b/apps/mobile/src/screens/PersonTaskDetailScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 import type { Task } from '@pmeow/app-common';
 import {
   formatTaskDetailValue,
@@ -7,7 +7,7 @@ import {
   formatTimestamp,
 } from '../app/formatters';
 import { styles } from '../app/styles';
-import { SectionCard } from '../components/common';
+import { PageSection, RefreshableScrollView } from '../components/common';
 import { formatMobileApiError, MobileApiClient, MobileApiError } from '../lib/api';
 
 function isTaskCancelable(task: Task | null): boolean {
@@ -149,89 +149,100 @@ export function PersonTaskDetailScreen(props: {
       : `任务 ID · ${formatTaskIdentifier(props.taskId)}`;
 
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
-      <SectionCard title="任务详情" description={summaryText}>
-        <Pressable
-          style={styles.detailBackButton}
-          onPress={props.onBack}
-        >
-          <Text style={styles.detailBackButtonText}>← 返回我的任务</Text>
-        </Pressable>
-        {notice ? <Text style={styles.noticeText}>{notice}</Text> : null}
-        {error ? <Text style={styles.errorText}>{error}</Text> : null}
-        {loading ? <Text style={styles.emptyText}>加载中...</Text> : null}
-        {!loading && !error ? <Text style={styles.connectionMeta}>任务 ID：{props.taskId}</Text> : null}
-      </SectionCard>
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
+      <Pressable style={styles.detailBackButton} onPress={props.onBack}>
+        <Text style={styles.detailBackButtonText}>← 返回我的任务</Text>
+      </Pressable>
+      <PageSection title="任务详情" description={summaryText}>
+        <View style={styles.sectionPanel}>
+          {notice ? <Text style={styles.noticeText}>{notice}</Text> : null}
+          {error ? <Text style={styles.errorText}>{error}</Text> : null}
+          {loading ? <Text style={styles.emptyText}>加载中...</Text> : null}
+          {!loading && !error ? <Text style={styles.connectionMeta}>任务 ID：{props.taskId}</Text> : null}
+        </View>
+      </PageSection>
 
       {!loading && !task ? (
-        <SectionCard title="无法显示详情" description="该记录可能已不存在或当前账号无权查看。">
-          <Pressable style={styles.secondaryButtonWide} onPress={() => void refreshTask()}>
-            <Text style={styles.secondaryButtonText}>重试</Text>
-          </Pressable>
-          <Pressable style={styles.ghostButtonWide} onPress={props.onBack}>
-            <Text style={styles.ghostButtonText}>返回</Text>
-          </Pressable>
-        </SectionCard>
+        <PageSection title="无法显示详情" description="该记录可能已不存在或当前账号无权查看。">
+          <View style={styles.sectionPanel}>
+            <Pressable style={styles.secondaryButtonWide} onPress={() => void refreshTask()}>
+              <Text style={styles.secondaryButtonText}>重试</Text>
+            </Pressable>
+            <Pressable style={styles.ghostButtonWide} onPress={props.onBack}>
+              <Text style={styles.ghostButtonText}>返回</Text>
+            </Pressable>
+          </View>
+        </PageSection>
       ) : null}
 
       {!loading && task ? (
         <>
-          <SectionCard title="主要信息" description="先看任务是什么、当前在哪台机器上。">
-            <View style={styles.panelStack}>
-              <DetailField label="命令" value={task.command} />
-              <DetailField label="服务器" value={task.serverId} />
-              <DetailField label="用户" value={task.user} />
-              <DetailField label="创建时间" value={formatTimestamp(task.createdAt)} />
+          <PageSection title="主要信息" description="先看任务是什么、当前在哪台机器上。">
+            <View style={styles.sectionPanel}>
+              <View style={styles.panelStack}>
+                <DetailField label="命令" value={task.command} />
+                <DetailField label="服务器" value={task.serverName} />
+                <DetailField label="用户" value={task.user} />
+                <DetailField label="创建时间" value={formatTimestamp(task.createdAt)} />
+              </View>
             </View>
-          </SectionCard>
+          </PageSection>
 
-          <SectionCard title="资源与启动信息" description="保留 web 端里最常用的调度和启动信息。">
-            <View style={styles.panelStack}>
-              <DetailField label="状态" value={formatTaskStatus(task.status)} />
-              <DetailField label="请求资源" value={formatRequestedResources(task)} />
-              <DetailField label="VRAM 模式" value={task.vramMode} />
-              <DetailField label="观察窗口" value={task.autoObserveWindowSec == null ? null : `${task.autoObserveWindowSec} 秒`} />
-              <DetailField label="观察峰值" value={formatPerGpuVramMap(task.autoPeakVramByGpuMb)} />
-              <DetailField label="回收状态" value={formatReclaimStatus(task)} />
-              <DetailField label="启动模式" value={task.launchMode} />
-              <DetailField label="优先级" value={task.priority} />
-              <DetailField label="指定 GPU" value={formatGpuList(task.gpuIds)} />
+          <PageSection title="资源与启动信息" description="保留 web 端里最常用的调度和启动信息。">
+            <View style={styles.sectionPanel}>
+              <View style={styles.panelStack}>
+                <DetailField label="状态" value={formatTaskStatus(task.status)} />
+                <DetailField label="请求资源" value={formatRequestedResources(task)} />
+                <DetailField label="VRAM 模式" value={task.vramMode} />
+                <DetailField label="观察窗口" value={task.autoObserveWindowSec == null ? null : `${task.autoObserveWindowSec} 秒`} />
+                <DetailField label="观察峰值" value={formatPerGpuVramMap(task.autoPeakVramByGpuMb)} />
+                <DetailField label="回收状态" value={formatReclaimStatus(task)} />
+                <DetailField label="启动模式" value={task.launchMode} />
+                <DetailField label="优先级" value={task.priority} />
+                <DetailField label="指定 GPU" value={formatGpuList(task.gpuIds)} />
+              </View>
             </View>
-          </SectionCard>
+          </PageSection>
 
-          <SectionCard title="运行状态信息" description="排查任务为什么没有启动或为什么结束。">
-            <View style={styles.panelStack}>
-              <DetailField label="工作目录" value={task.cwd} />
-              <DetailField label="开始时间" value={task.startedAt ? formatTimestamp(task.startedAt) : null} />
-              <DetailField label="结束时间" value={task.finishedAt ? formatTimestamp(task.finishedAt) : null} />
-              <DetailField label="PID" value={task.pid} />
-              <DetailField label="退出码" value={task.exitCode} />
-              <DetailField label="结束原因" value={task.endReason} />
+          <PageSection title="运行状态信息" description="排查任务为什么没有启动或为什么结束。">
+            <View style={styles.sectionPanel}>
+              <View style={styles.panelStack}>
+                <DetailField label="工作目录" value={task.cwd} />
+                <DetailField label="开始时间" value={task.startedAt ? formatTimestamp(task.startedAt) : null} />
+                <DetailField label="结束时间" value={task.finishedAt ? formatTimestamp(task.finishedAt) : null} />
+                <DetailField label="PID" value={task.pid} />
+                <DetailField label="退出码" value={task.exitCode} />
+                <DetailField label="结束原因" value={task.endReason} />
+              </View>
             </View>
-          </SectionCard>
+          </PageSection>
 
           {task.assignedGpus && task.assignedGpus.length > 0 ? (
-            <SectionCard title="已分配 GPU" description="任务已经占用的显卡列表。">
-              <View style={styles.panelStack}>
-                <DetailField label="GPU 列表" value={formatGpuList(task.assignedGpus)} />
-                <DetailField label="每 GPU 声明显存" value={task.declaredVramPerGpu == null ? null : `${task.declaredVramPerGpu} MB`} />
+            <PageSection title="已分配 GPU" description="任务已经占用的显卡列表。">
+              <View style={styles.sectionPanel}>
+                <View style={styles.panelStack}>
+                  <DetailField label="GPU 列表" value={formatGpuList(task.assignedGpus)} />
+                  <DetailField label="每 GPU 声明显存" value={task.declaredVramPerGpu == null ? null : `${task.declaredVramPerGpu} MB`} />
+                </View>
               </View>
-            </SectionCard>
+            </PageSection>
           ) : null}
 
           {isTaskCancelable(task) ? (
-            <SectionCard title="操作" description="只能取消当前仍在排队或运行中的任务。">
-              <Pressable
-                style={[styles.primaryButton, pendingCancel ? styles.buttonDisabled : null]}
-                disabled={pendingCancel}
-                onPress={() => void handleCancelTask()}
-              >
-                <Text style={styles.primaryButtonText}>{pendingCancel ? '提交中...' : '取消任务'}</Text>
-              </Pressable>
-            </SectionCard>
+            <PageSection title="操作" description="只能取消当前仍在排队或运行中的任务。">
+              <View style={styles.sectionPanel}>
+                <Pressable
+                  style={[styles.primaryButton, pendingCancel ? styles.buttonDisabled : null]}
+                  disabled={pendingCancel}
+                  onPress={() => void handleCancelTask()}
+                >
+                  <Text style={styles.primaryButtonText}>{pendingCancel ? '提交中...' : '取消任务'}</Text>
+                </Pressable>
+              </View>
+            </PageSection>
           ) : null}
         </>
       ) : null}
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }

--- a/apps/mobile/src/screens/ServerDetailScreen.tsx
+++ b/apps/mobile/src/screens/ServerDetailScreen.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Pressable, ScrollView, Switch, Text, TextInput, View } from 'react-native';
+import { Pressable, Switch, Text, TextInput, View } from 'react-native';
 import type { Server, ServerStatus, UnifiedReport } from '@pmeow/app-common';
 import { formatPercent, formatTimestamp } from '../app/formatters';
 import { computeGpuTotals, formatMemoryGb, formatMemoryPairGb, getUsagePalette, type HostRealtimeHistory, type PerGpuRealtimeHistory } from '../app/metrics';
 import { SERVER_DETAIL_SECONDARY_PAGES, type ServerDetailSecondaryPageId } from '../app/navigation';
 import { styles } from '../app/styles';
-import { ExpandableList, QueueTaskRow, SectionCard, SecondarySwipeView, StatBlock } from '../components/common';
+import { ExpandableList, QueueTaskRow, RefreshableScrollView, SectionCard, SecondarySwipeView, StatBlock } from '../components/common';
 import { DEFAULT_IDLE_GPU_NOTIFICATION_RULE, type IdleGpuNotificationRule } from '../lib/preferences';
 import { CpuMemoryTrendCard, DiskUsageSection, GpuRealtimeSection, VramDistributionSection } from '../components/monitoring';
 
@@ -41,6 +41,7 @@ function TaskQueueSection(props: {
   title: string;
   emptyText: string;
   tasks: Array<Parameters<typeof QueueTaskRow>[0]['task']>;
+  onSelectTask?: (taskId: string) => void;
 }) {
   return (
     <View style={styles.detailPanel}>
@@ -54,7 +55,13 @@ function TaskQueueSection(props: {
           renderItems={(expanded) => {
             const visibleTasks = expanded ? props.tasks : props.tasks.slice(0, 5);
 
-            return visibleTasks.map((task) => <QueueTaskRow key={task.taskId} task={task} />);
+            return visibleTasks.map((task) => (
+              <QueueTaskRow
+                key={task.taskId}
+                task={task}
+                onPress={props.onSelectTask ? () => props.onSelectTask?.(task.taskId) : undefined}
+              />
+            ));
           }}
         />
       )}
@@ -75,6 +82,7 @@ export function ServerDetailScreen(props: {
   onBack: () => void;
   onToggleSubscription: () => void;
   onSaveSubscriptionRule: (rule: IdleGpuNotificationRule) => void;
+  onSelectTask?: (taskId: string) => void;
 }) {
   const gpuCards = props.report?.resourceSnapshot.gpuCards ?? [];
   const gpuTotals = computeGpuTotals(gpuCards);
@@ -301,16 +309,16 @@ export function ServerDetailScreen(props: {
             <StatBlock label="总任务数" value={runningTasks.length + queuedTasks.length + recentlyEndedTasks.length} />
           </View>
           <View style={styles.panelStack}>
-            <TaskQueueSection title="运行中任务" emptyText="当前没有运行中的任务。" tasks={runningTasks} />
-            <TaskQueueSection title="排队任务" emptyText="当前没有排队任务。" tasks={queuedTasks} />
-            <TaskQueueSection title="最近结束任务" emptyText="当前没有最近结束的任务。" tasks={recentlyEndedTasks} />
+            <TaskQueueSection title="运行中任务" emptyText="当前没有运行中的任务。" tasks={runningTasks} onSelectTask={props.onSelectTask} />
+            <TaskQueueSection title="排队任务" emptyText="当前没有排队任务。" tasks={queuedTasks} onSelectTask={props.onSelectTask} />
+            <TaskQueueSection title="最近结束任务" emptyText="当前没有最近结束的任务。" tasks={recentlyEndedTasks} onSelectTask={props.onSelectTask} />
           </View>
         </SectionCard>
     );
   };
 
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
       <View style={styles.serverDetailHeaderCompact}>
         <View style={styles.serverDetailHeaderRow}>
           <Pressable style={styles.detailBackButton} onPress={props.onBack}>
@@ -339,6 +347,6 @@ export function ServerDetailScreen(props: {
         tabBlockSize={3}
         renderPage={renderDetailPage}
       />
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { Pressable, ScrollView, Switch, Text, View } from 'react-native';
+import { Pressable, Switch, Text, View } from 'react-native';
 import type { Server } from '@pmeow/app-common';
 import type { NotificationInboxItem } from '../lib/notification-inbox';
-import { ADMIN_SETTINGS_SECONDARY_PAGES, type AdminSettingsSecondaryPageId } from '../app/navigation';
+import { ADMIN_SETTINGS_SECONDARY_PAGES, PERSON_SETTINGS_SECONDARY_PAGES, type AdminSettingsSecondaryPageId, type PersonSettingsSecondaryPageId } from '../app/navigation';
 import { styles } from '../app/styles';
-import { NotificationInboxSection, PageSection, SecondarySwipeView } from '../components/common';
+import { NotificationInboxSection, PageSection, RefreshableScrollView, SecondarySwipeView } from '../components/common';
 
 export function SettingsScreen(props: {
   baseUrl: string;
@@ -181,9 +181,11 @@ export function SettingsScreen(props: {
     </View>
   );
 
+  const [activePersonPage, setActivePersonPage] = useState<PersonSettingsSecondaryPageId>('localNotifications');
+
   if (props.isAdmin) {
     return (
-      <ScrollView contentContainerStyle={styles.screenContent}>
+      <RefreshableScrollView contentContainerStyle={styles.screenContent}>
         <PageSection title="设置" description="按模块管理本机通知、通知记录和当前连接。">
           <SecondarySwipeView
             pages={ADMIN_SETTINGS_SECONDARY_PAGES}
@@ -207,24 +209,35 @@ export function SettingsScreen(props: {
             }}
           />
         </PageSection>
-      </ScrollView>
+      </RefreshableScrollView>
     );
   }
 
   return (
-    <ScrollView contentContainerStyle={styles.screenContent}>
-      <PageSection title="本地通知设置" description="所有开关与订阅都只保存在本机。">
-        {notificationSettings}
+    <RefreshableScrollView contentContainerStyle={styles.screenContent}>
+      <PageSection title="设置" description="按模块管理本机通知、通知记录和当前连接。">
+        <SecondarySwipeView
+          pages={PERSON_SETTINGS_SECONDARY_PAGES}
+          activePage={activePersonPage}
+          onChangePage={setActivePersonPage}
+          renderPage={(page) => {
+            if (page === 'localNotifications') {
+              return notificationSettings;
+            }
+            if (page === 'notificationInbox') {
+              return <NotificationInboxSection items={props.notificationInbox} initialVisibleCount={8} />;
+            }
+            return (
+              <View style={styles.sectionPanel}>
+                <Text style={styles.connectionMeta}>当前后端：{props.baseUrl}</Text>
+                <Pressable style={styles.ghostButtonWide} onPress={() => void props.onSignOut()}>
+                  <Text style={styles.ghostButtonText}>退出登录</Text>
+                </Pressable>
+              </View>
+            );
+          }}
+        />
       </PageSection>
-
-      <NotificationInboxSection items={props.notificationInbox} initialVisibleCount={8} />
-
-      <PageSection title="当前连接" description="连接地址仅用于当前 PMEOW 后端。">
-        <Text style={styles.connectionMeta}>当前后端：{props.baseUrl}</Text>
-        <Pressable style={styles.ghostButtonWide} onPress={() => void props.onSignOut()}>
-          <Text style={styles.ghostButtonText}>退出登录</Text>
-        </Pressable>
-      </PageSection>
-    </ScrollView>
+    </RefreshableScrollView>
   );
 }

--- a/apps/mobile/src/store/overview.ts
+++ b/apps/mobile/src/store/overview.ts
@@ -5,7 +5,7 @@ import type { OverviewData } from './types';
 
 export async function loadOverview(client: MobileApiClient, session: AuthSession): Promise<OverviewData> {
   const personTasksPromise = session.authenticated && session.principal.kind === 'person' && session.person
-    ? client.getPersonTasks(session.person.id, { limit: 10 })
+    ? client.getPersonTasks(session.person.id, { limit: 50 })
     : Promise.resolve({ tasks: [], total: 0 });
 
   const alertsPromise = session.authenticated && session.principal.kind === 'admin'

--- a/apps/mobile/tests/navigation-structure.test.ts
+++ b/apps/mobile/tests/navigation-structure.test.ts
@@ -1,15 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   ADMIN_DETAIL_ROUTES,
   ADMIN_ALERT_SECONDARY_PAGES,
   ADMIN_SETTINGS_SECONDARY_PAGES,
   ADMIN_TAB_ROUTES,
+  PERSON_NOTIFICATION_SECONDARY_PAGES,
+  PERSON_SETTINGS_SECONDARY_PAGES,
+  PERSON_TASK_SECONDARY_PAGES,
   SERVER_DETAIL_SECONDARY_PAGES,
   getServerDetailSecondaryPageBlocks,
   MOBILE_INFORMATION_MAP,
   PERSON_DETAIL_ROUTES,
   PERSON_TAB_ROUTES,
 } from '../src/app/navigation';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const mobileSrcDir = join(testDir, '..', 'src');
 
 describe('mobile role navigation structure', () => {
   it('keeps ops/admin and person tabs role-specific', () => {
@@ -22,7 +31,23 @@ describe('mobile role navigation structure', () => {
     expect(PERSON_TAB_ROUTES.map((route) => route.name)).toEqual([
       'Resources',
       'MyTasks',
+      'Notifications',
       'PersonSettings',
+    ]);
+  });
+
+  it('provides an icon identity for every main tab', () => {
+    expect(ADMIN_TAB_ROUTES.map((route) => route.icon)).toEqual([
+      'overview',
+      'nodes',
+      'alerts',
+      'settings',
+    ]);
+    expect(PERSON_TAB_ROUTES.map((route) => route.icon)).toEqual([
+      'resources',
+      'tasks',
+      'notifications',
+      'settings',
     ]);
   });
 
@@ -50,6 +75,23 @@ describe('mobile role navigation structure', () => {
     ]);
   });
 
+  it('defines secondary pages for person task and settings sections', () => {
+    expect(PERSON_TASK_SECONDARY_PAGES.map((page) => page.id)).toEqual([
+      'inProgress',
+      'completed',
+      'all',
+    ]);
+    expect(PERSON_NOTIFICATION_SECONDARY_PAGES.map((page) => page.id)).toEqual([
+      'taskEvents',
+      'notificationInbox',
+    ]);
+    expect(PERSON_SETTINGS_SECONDARY_PAGES.map((page) => page.id)).toEqual([
+      'localNotifications',
+      'notificationInbox',
+      'connection',
+    ]);
+  });
+
   it('keeps server detail secondary tabs in one swipeable row', () => {
     expect(SERVER_DETAIL_SECONDARY_PAGES.map((page) => page.id)).toEqual([
       'overview',
@@ -65,6 +107,36 @@ describe('mobile role navigation structure', () => {
       ['overview', 'realtime', 'disk'],
       ['vram', 'tasks'],
     ]);
+  });
+});
+
+describe('mobile pull-to-refresh structure', () => {
+  it('uses pull-to-refresh scroll containers on authenticated screens', () => {
+    const screenFiles = [
+      'screens/AdminScreens.tsx',
+      'screens/PersonScreens.tsx',
+      'screens/ServerDetailScreen.tsx',
+      'screens/PersonTaskDetailScreen.tsx',
+      'screens/SettingsScreen.tsx',
+    ];
+
+    for (const screenFile of screenFiles) {
+      const source = readFileSync(join(mobileSrcDir, screenFile), 'utf8');
+      expect(source, screenFile).toContain('RefreshableScrollView');
+      expect(source, screenFile).not.toContain('<ScrollView contentContainerStyle={styles.screenContent}');
+    }
+  });
+
+  it('removes manual refresh buttons from the authenticated shell', () => {
+    const source = readFileSync(join(mobileSrcDir, 'components/common.tsx'), 'utf8');
+    expect(source).not.toContain('compactRefreshButton');
+    expect(source).not.toContain('refreshButton');
+    expect(source).not.toContain('刷新中');
+  });
+
+  it('keeps authenticated fallback pages refreshable', () => {
+    const source = readFileSync(join(mobileSrcDir, 'App.tsx'), 'utf8');
+    expect(source.match(/<RefreshableScrollView contentContainerStyle=\{styles\.screenContent\}>/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -93,8 +165,8 @@ describe('mobile information parity map', () => {
     expect(MOBILE_INFORMATION_MAP.person).toMatchObject({
       machineSummary: 'Resources',
       gpuIdleMachineView: 'Resources',
-      recentTaskEvents: 'Resources',
-      notificationInbox: 'Resources',
+      recentTaskEvents: 'Notifications',
+      notificationInbox: 'Notifications',
       personTasks: 'MyTasks',
       cancelTask: 'MyTasks',
       notificationSettings: 'PersonSettings',


### PR DESCRIPTION
## Summary

Upgrade the regular user (person) mobile UI to parity with the recent admin UI redesign, adding secondary pages, dashboard hero, a new Notifications tab, and click-to-detail navigation throughout.

### Key changes

- **Pull-to-refresh**: Replace manual refresh buttons with native `RefreshControl` via `RefreshableScrollView` + `PullToRefreshContext`
- **Notifications tab**: New 4th tab with `SecondarySwipeView` (task events + notification inbox sub-pages), bell icon
- **Person home screen**: Dashboard hero (machine health percentage + progress bar), pressable action cards navigating to tasks/notifications tabs
- **Task screen**: `SecondarySwipeView` with 3 status tabs (进行中 / 已结束 / 全部), defaults to "全部"
- **Task detail**: `SectionCard` → `PageSection` throughout, server field now shows `serverName` instead of `serverId`
- **Settings**: Person settings now use `SecondarySwipeView` matching admin settings layout
- **Click navigation**: Action cards, task events in notifications, and `QueueTaskRow` items in server detail all navigate to relevant detail screens
- **Task limit**: Increased from 10 to 50

### Test plan

- [x] `npx vitest run` — 12/12 tests pass
- [x] `npx tsc --noEmit` — clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)